### PR TITLE
turn off dynamic colors in fuzzy search

### DIFF
--- a/ui/fuzzy-search-modal.go
+++ b/ui/fuzzy-search-modal.go
@@ -60,7 +60,6 @@ func NewFuzzySearchModal(mainView *MainView, width int, height int) *FuzzySearch
 		SetInputCapture(fs.keyHandler)
 
 	fs.results = tview.NewTextView().
-		SetDynamicColors(true).
 		SetRegions(true)
 	fs.results.SetBorderPadding(1, 0, 0, 0)
 


### PR DESCRIPTION
This option causes issues for room titles like `[Discord] Foobar Room`.  It doesn't seem like it was being used anyway.