### PR TITLE
Add support for more key events

### DIFF
--- a/ui/commands.go
+++ b/ui/commands.go
@@ -18,10 +18,10 @@ package ui
 
 import (
 	"encoding/json"
-	"maunium.net/go/gomuks/debug"
-	"strings"
 	"fmt"
 	"github.com/lucasb-eyer/go-colorful"
+	"maunium.net/go/gomuks/debug"
+	"strings"
 	"unicode"
 )
 
@@ -74,7 +74,7 @@ func cmdRainbow(cmd *Command) {
 			html.WriteRune(char)
 			continue
 		}
-		color := rainbow.GetInterpolatedColorFor(float64(i)/float64(len(text))).Hex()
+		color := rainbow.GetInterpolatedColorFor(float64(i) / float64(len(text))).Hex()
 		fmt.Fprintf(&html, "<font color=\"%s\">%c</font>", color, char)
 	}
 	tempMessage := cmd.Room.NewTempMessage("m.text", html.String())

--- a/ui/view-main.go
+++ b/ui/view-main.go
@@ -193,10 +193,10 @@ func (view *MainView) KeyEventHandler(roomView *RoomView, key *tcell.EventKey) *
 		default:
 			return key
 		}
-    } else if k == tcell.KeyAltDown || k == tcell.KeyCtrlDown {
-        view.SwitchRoom(view.roomList.Next())
-    } else if k == tcell.KeyAltUp || k == tcell.KeyCtrlUp {
-        view.SwitchRoom(view.roomList.Previous())
+	} else if k == tcell.KeyAltDown || k == tcell.KeyCtrlDown {
+		view.SwitchRoom(view.roomList.Next())
+	} else if k == tcell.KeyAltUp || k == tcell.KeyCtrlUp {
+		view.SwitchRoom(view.roomList.Previous())
 	} else if k == tcell.KeyPgUp || k == tcell.KeyPgDn || k == tcell.KeyUp || k == tcell.KeyDown || k == tcell.KeyEnd || k == tcell.KeyHome {
 		msgView := roomView.MessageView()
 

--- a/ui/view-main.go
+++ b/ui/view-main.go
@@ -195,7 +195,7 @@ func (view *MainView) KeyEventHandler(roomView *RoomView, key *tcell.EventKey) *
 		}
     } else if k == tcell.KeyAltDown || k == tcell.KeyCtrlDown {
         view.SwitchRoom(view.roomList.Next())
-    } else if k == tcell.KeyAltUp || k == tcell.KeyCtrlUp
+    } else if k == tcell.KeyAltUp || k == tcell.KeyCtrlUp {
         view.SwitchRoom(view.roomList.Previous())
 	} else if k == tcell.KeyPgUp || k == tcell.KeyPgDn || k == tcell.KeyUp || k == tcell.KeyDown || k == tcell.KeyEnd || k == tcell.KeyHome {
 		msgView := roomView.MessageView()

--- a/ui/view-main.go
+++ b/ui/view-main.go
@@ -193,6 +193,10 @@ func (view *MainView) KeyEventHandler(roomView *RoomView, key *tcell.EventKey) *
 		default:
 			return key
 		}
+    } else if k == tcell.KeyAltDown || k == tcell.KeyCtrlDown {
+        view.SwitchRoom(view.roomList.Next())
+    } else if k == tcell.KeyAltUp || k == tcell.KeyCtrlUp
+        view.SwitchRoom(view.roomList.Previous())
 	} else if k == tcell.KeyPgUp || k == tcell.KeyPgDn || k == tcell.KeyUp || k == tcell.KeyDown || k == tcell.KeyEnd || k == tcell.KeyHome {
 		msgView := roomView.MessageView()
 


### PR DESCRIPTION
In some cases tcell sends Key{Ctrl,Alt}{Up,Down} events instead of
Key{Up,Down} event that have the corresponding modifier mask set.
(these key combinations are used for switching rooms)