### PR TITLE
Clarifying the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ or compile from source:
 - jump to room - `Alt + Enter`, then `Tab` and `Enter` to navigate and select room
 
 ### Commands
-* `help` - Is a known command
-* `me <text>` - Send an emote
-* `quit` - Close gomuks
-* `clearcache` - Clear room state and close gomuks
-* `leave` - Leave the current room
-* `join <room>` - Join the room with the given room ID or alias
-* `toggle <rooms/users/baremessages/images/typingnotif>` - Change user preferences
-* `logout` - Log out, clear caches and go back to the login view
-* `send <room id> <event type> <content>` - Send a custom event
-* `setstate <room id> <event type> <state key/`-`> <content>` - Change room state
+* `/help` - Is a known command
+* `/me <text>` - Send an emote
+* `/quit` - Close gomuks
+* `/clearcache` - Clear room state and close gomuks
+* `/leave` - Leave the current room
+* `/join <room>` - Join the room with the given room ID or alias
+* `/toggle <rooms/users/baremessages/images/typingnotif>` - Change user preferences
+* `/logout` - Log out, clear caches and go back to the login view
+* `/send <room id> <event type> <content>` - Send a custom event
+* `/setstate <room id> <event type> <state key/`-`> <content>` - Change room state


### PR DESCRIPTION
Hey all!
The README provides a good overview of the some functions and commands that gomuks can interpret.
However commands are invoked by a leading slash prior to the command. That got me confused, because I didn't look into the wiki directly.

I suggest printing the slash in front of commands in the README as well, so that CLI tool newbies like me don't get confused. I guess slashes are the standard operator for invoking options. I remember that profanity and other tools did this as well. My bad.

What do you think?

Regards
Patrik