### PR TITLE
Alt-a to jump to next channel with unread messages.

### DIFF
--- a/ui/room-list.go
+++ b/ui/room-list.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"math"
+
 	"maunium.net/go/gomuks/debug"
 	"maunium.net/go/gomuks/matrix/rooms"
 	"maunium.net/go/tcell"
@@ -311,6 +312,27 @@ func (list *RoomList) Next() (string, *rooms.Room) {
 		return list.selectedTag, trl.Visible()[index-1].Room
 	}
 	return list.Last()
+}
+
+// NextWithActivity Returns next room with activity.
+//
+// Sorted by (in priority):
+//
+// - Highlights
+// - Messages
+// - Other traffic (joins, parts, etc)
+//
+// TODO: Sorting. Now just finds first room with new messages.
+func (list *RoomList) NextWithActivity() (string, *rooms.Room) {
+	for tag, trl := range list.items {
+		for _, room := range trl.All() {
+			if room.HasNewMessages() {
+				return tag, room.Room
+			}
+		}
+	}
+	// No room with activity found
+	return "", nil
 }
 
 func (list *RoomList) index(tag string, room *rooms.Room) int {

--- a/ui/tag-room-list.go
+++ b/ui/tag-room-list.go
@@ -18,12 +18,13 @@ package ui
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
+
 	"maunium.net/go/gomuks/matrix/rooms"
 	"maunium.net/go/gomuks/ui/widget"
 	"maunium.net/go/tcell"
 	"maunium.net/go/tview"
-	"strconv"
-	"strings"
 )
 
 type OrderedRoom struct {

--- a/ui/view-main.go
+++ b/ui/view-main.go
@@ -196,6 +196,8 @@ func (view *MainView) KeyEventHandler(roomView *RoomView, key *tcell.EventKey) *
 			searchModal := NewFuzzySearchModal(view, 42, 12)
 			view.parent.views.AddPage("fuzzy-search-modal", searchModal, true, true)
 			view.parent.app.SetFocus(searchModal)
+		case c == 'a':
+			view.SwitchRoom(view.roomList.NextWithActivity())
 		case c == 'l':
 			view.ShowBare(roomView)
 		default:


### PR DESCRIPTION
Alt-a is "standard" in irssi & weechat to jump to next channel with activity. This implement basic functionality for it. Does not sort by priority yet but seems to work. 