### PR TITLE
Alt-numbers and top row to switch channels

### DIFF
--- a/ui/room-list.go
+++ b/ui/room-list.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"math"
+
 	"maunium.net/go/gomuks/debug"
 	"maunium.net/go/gomuks/matrix/rooms"
 	"maunium.net/go/tcell"
@@ -311,6 +312,22 @@ func (list *RoomList) Next() (string, *rooms.Room) {
 		return list.selectedTag, trl.Visible()[index-1].Room
 	}
 	return list.Last()
+}
+
+// At returns room at given index from top of the list
+// or none if such room doesn't exist
+func (list *RoomList) At(index int) (string, *rooms.Room) {
+	i := 0
+	for _, tag := range list.tags {
+		trl := list.items[tag]
+		for j := trl.Length() - 1; j >= 0; j-- {
+			if index == i {
+				return tag, trl.rooms[j].Room
+			}
+			i++
+		}
+	}
+	return "", nil
 }
 
 func (list *RoomList) index(tag string, room *rooms.Room) int {

--- a/ui/view-main.go
+++ b/ui/view-main.go
@@ -196,6 +196,46 @@ func (view *MainView) KeyEventHandler(roomView *RoomView, key *tcell.EventKey) *
 			searchModal := NewFuzzySearchModal(view, 42, 12)
 			view.parent.views.AddPage("fuzzy-search-modal", searchModal, true, true)
 			view.parent.app.SetFocus(searchModal)
+		case c == '1':
+			view.SwitchRoom(view.roomList.At(0))
+		case c == '2':
+			view.SwitchRoom(view.roomList.At(1))
+		case c == '3':
+			view.SwitchRoom(view.roomList.At(2))
+		case c == '4':
+			view.SwitchRoom(view.roomList.At(3))
+		case c == '5':
+			view.SwitchRoom(view.roomList.At(4))
+		case c == '6':
+			view.SwitchRoom(view.roomList.At(5))
+		case c == '7':
+			view.SwitchRoom(view.roomList.At(6))
+		case c == '8':
+			view.SwitchRoom(view.roomList.At(7))
+		case c == '9':
+			view.SwitchRoom(view.roomList.At(8))
+		case c == '0':
+			view.SwitchRoom(view.roomList.At(9))
+		case c == 'q':
+			view.SwitchRoom(view.roomList.At(10))
+		case c == 'w':
+			view.SwitchRoom(view.roomList.At(11))
+		case c == 'e':
+			view.SwitchRoom(view.roomList.At(12))
+		case c == 'r':
+			view.SwitchRoom(view.roomList.At(13))
+		case c == 't':
+			view.SwitchRoom(view.roomList.At(14))
+		case c == 'y':
+			view.SwitchRoom(view.roomList.At(15))
+		case c == 'u':
+			view.SwitchRoom(view.roomList.At(16))
+		case c == 'i':
+			view.SwitchRoom(view.roomList.At(17))
+		case c == 'o':
+			view.SwitchRoom(view.roomList.At(18))
+		case c == 'p':
+			view.SwitchRoom(view.roomList.At(19))
 		case c == 'l':
 			view.ShowBare(roomView)
 		default:


### PR DESCRIPTION
alt-1 is the first channels, alt-2 second etc, continuing on second row (qwerty..) allowing up to 20 channels.

Note: There seems to be some weirdness going to higher number of channels - gomuks shows the channel buffer but they are not listed in channel list. Might be bug here or somewhere else.