### PR TITLE
Users can now create a new room directly in Gomuks

### DIFF
--- a/matrix/matrix.go
+++ b/matrix/matrix.go
@@ -538,6 +538,16 @@ func (c *Container) SendTyping(roomID string, typing bool) {
 	}
 }
 
+// CreateRoom attempts to create a new room and join the user.
+func (c *Container) CreateRoom(req *mautrix.ReqCreateRoom) (*rooms.Room, error) {
+	resp, err := c.client.CreateRoom(req)
+	if err != nil {
+		return nil, err
+	}
+	room := c.GetRoom(resp.RoomID)
+	return room, nil
+}
+
 // JoinRoom makes the current user try to join the given room.
 func (c *Container) JoinRoom(roomID, server string) (*rooms.Room, error) {
 	resp, err := c.client.JoinRoom(roomID, server, nil)

--- a/ui/command-processor.go
+++ b/ui/command-processor.go
@@ -90,6 +90,7 @@ func NewCommandProcessor(parent *MainView) *CommandProcessor {
 			"quit":            cmdQuit,
 			"clearcache":      cmdClearCache,
 			"leave":           cmdLeave,
+			"create":          cmdCreateRoom,
 			"join":            cmdJoin,
 			"kick":            cmdKick,
 			"ban":             cmdBan,

--- a/ui/commands.go
+++ b/ui/commands.go
@@ -121,6 +121,7 @@ func cmdHelp(cmd *Command) {
 /me <message>      - Send an emote message.
 /rainbow <message> - Send a rainbow message (markdown not supported).
 
+/create <Room Name> <RoomAlias> - Create a room with associated alias. (Alias must not contain spaces.)
 /join <room address> - Join a room.
 /leave               - Leave the current room.
 
@@ -201,6 +202,33 @@ func cmdKick(cmd *Command) {
 		debug.Print("Failed to kick user:", err)
 	}
 
+}
+
+func cmdCreateRoom(cmd *Command) {
+	if len(cmd.Args) < 2 {
+		cmd.Reply("Usage: /create <Room Name> <RoomAlias> (Alias must not contain spaces.)")
+		return
+	}
+	// Get room name as one string from cmd.Args
+	roomName := ""
+	for i, v := range cmd.Args {
+		if i == len(cmd.Args)-1 {
+			break
+		}
+		roomName += fmt.Sprintf("%s ", v)
+	}
+	last := len(cmd.Args) - 1 // last arg for room alias
+	// Build the ReqCreateRoom Struct
+	// https://godoc.org/maunium.net/go/mautrix#ReqCreateRoom
+	req := &mautrix.ReqCreateRoom{
+		Name:          strings.TrimSpace(roomName),
+		RoomAliasName: cmd.Args[last],
+	}
+	_, err := cmd.Matrix.Client().CreateRoom(req)
+	debug.Print("Create room error:", err)
+	if err == nil {
+		cmd.Reply("The room has been created.")
+	}
 }
 
 func cmdJoin(cmd *Command) {


### PR DESCRIPTION
Added the ability to create a room from within gomuks using the now
`/create` command. This command takes the room name followed by the
alias. Room name may contain spaces but the alias may not as per the
Matrix alias conventions.

Also updated `/help` in `ui/command-processor.go` to include the new command.
Added the needed `CreateRoom` func to `matrix/matrix.go`

This should satisfy issue #5.