### PR TITLE
Fix unexpected program exit on failed login; debuglog call tweaks

### DIFF
--- a/ui/view-login.go
+++ b/ui/view-login.go
@@ -75,7 +75,7 @@ func (ui *GomuksUI) NewLoginView() mauview.Component {
 	view.password.SetMaskCharacter('*')
 
 	view.quitButton.SetOnClick(func() { ui.gmx.Stop(true) }).SetBackgroundColor(tcell.ColorDarkCyan)
-	view.loginButton.SetOnClick(view.Login).SetBackgroundColor(tcell.ColorDarkCyan)
+	view.loginButton.SetOnClick(func() { view.Login(); view.FocusNextItem(); }).SetBackgroundColor(tcell.ColorDarkCyan)
 
 	view.SetColumns([]int{1, 10, 1, 9, 1, 9, 1, 10, 1})
 	view.SetRows([]int{1, 1, 1, 1, 1, 1, 1, 1, 1, 1})

--- a/ui/view-login.go
+++ b/ui/view-login.go
@@ -120,7 +120,9 @@ func (view *LoginView) Login() {
 	debug.Printf("Logging into %s as %s...", hs, mxid)
 	view.config.HS = hs
 	err := view.matrix.InitClient()
-	debug.Print("Init error:", err)
+	if err != nil {
+		debug.Print("Init error:", err)
+	}
 	err = view.matrix.Login(mxid, password)
 	if err != nil {
 		if httpErr, ok := err.(mautrix.HTTPError); ok {

--- a/ui/view-login.go
+++ b/ui/view-login.go
@@ -125,6 +125,7 @@ func (view *LoginView) Login() {
 	}
 	err = view.matrix.Login(mxid, password)
 	if err != nil {
+		debug.Print("Login error:", err)
 		if httpErr, ok := err.(mautrix.HTTPError); ok {
 			if httpErr.RespError != nil {
 				view.Error(httpErr.RespError.Err)
@@ -134,6 +135,5 @@ func (view *LoginView) Login() {
 		} else {
 			view.Error("Failed to connect to server.")
 		}
-		debug.Print("Login error:", err)
 	}
 }


### PR DESCRIPTION
After a `loginButton` press, the mauview stack appears to unconditionally set focus to the next item in the form; in this case the `quitButton`. For reasons I don't quite understand yet, the `SetOnClick()` handler for the quit button is invoked and the program quits.

This fixes that action by skipping the `quitButton` and allowing the UI to continue; in the case of login failure, displaying the error, and focus on the `username` `InputField` (though that is not focused explicitly).