### PR TITLE
Don't display full username address in placeholder

### DIFF
--- a/ui/view-login.go
+++ b/ui/view-login.go
@@ -75,7 +75,7 @@ func (ui *GomuksUI) NewLoginView() mauview.Component {
 
 	hs := ui.gmx.Config().HS
 	view.homeserver.SetPlaceholder("https://example.com").SetText(hs)
-	view.username.SetPlaceholder("@user:example.com").SetText(ui.gmx.Config().UserID)
+	view.username.SetPlaceholder("exampleuser").SetText(ui.gmx.Config().UserID)
 	view.password.SetPlaceholder("correct horse battery staple").SetMaskCharacter('*')
 
 	view.quitButton.SetOnClick(func() { ui.gmx.Stop(true) }).SetBackgroundColor(tcell.ColorDarkCyan)


### PR DESCRIPTION
One would not enter `@user:example.com`. In fact, when I try entering `@example:ordoevangelistarum.com`, it throws the error `invalid character '<' looking for beginning of value`. The same applies to `@example:glowers.club` and `@example:nerdsin.space`.

Having it display `exampleuser` instead is more correct.