### PR TITLE
Fix command autocompletion

### DIFF
--- a/ui/command-processor.go
+++ b/ui/command-processor.go
@@ -24,7 +24,7 @@ import (
 
 	"maunium.net/go/gomuks/config"
 	"maunium.net/go/gomuks/debug"
-	"maunium.net/go/gomuks/interface"
+	ifc "maunium.net/go/gomuks/interface"
 )
 
 type gomuksPointerContainer struct {
@@ -222,7 +222,7 @@ func (ch *CommandProcessor) Autocomplete(roomView *RoomView, text string, cursor
 			text = newText
 		}
 	}
-	return completions, text, true
+	return completions, text, ok
 }
 
 func (ch *CommandProcessor) AutocompleteCommand(word string) (completions []string) {


### PR DESCRIPTION
https://github.com/tulir/gomuks/blob/286c6fce01e12779c4f2dd1bbeda86f1029fa49e/ui/command-processor.go#L225

This `true` should be replaced with `ok`. If following line fails, we wouldn't have any completions at all
https://github.com/tulir/gomuks/blob/286c6fce01e12779c4f2dd1bbeda86f1029fa49e/ui/command-processor.go#L217