### PR TITLE
Fix crash when using /o command

### DIFF
--- a/ui/room-view.go
+++ b/ui/room-view.go
@@ -459,10 +459,10 @@ func (view *RoomView) filterOwnOnly(evt *muksevt.Event) bool {
 
 func (view *RoomView) filterMediaOnly(evt *muksevt.Event) bool {
 	content, ok := evt.Content.Parsed.(*event.MessageEventContent)
-	return ok && content.MsgType == event.MsgFile ||
+	return ok && (content.MsgType == event.MsgFile ||
 		content.MsgType == event.MsgImage ||
 		content.MsgType == event.MsgAudio ||
-		content.MsgType == event.MsgVideo
+		content.MsgType == event.MsgVideo)
 }
 
 func (view *RoomView) findMessage(current *muksevt.Event, forward bool, allow findFilter) *messages.UIMessage {


### PR DESCRIPTION
The crash happens sometimes when selecting media to download. The crash happens when ok is false.
Here is a stacktrace:
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xae194b]

goroutine 1 [running]:
maunium.net/go/gomuks/debug.Recover()
        /home//git/gomuks/debug/debug.go:109 +0x94
panic(0xb5fe00, 0x1374300)
        /usr/lib/go/src/runtime/panic.go:969 +0x166
maunium.net/go/mauview.(*Application).Start.func1(0xc0003b9200)
        /home//go/pkg/mod/maunium.net/go/mauview@v0.1.1/application.go:99 +0x82
panic(0xb5fe00, 0x1374300)
        /usr/lib/go/src/runtime/panic.go:969 +0x166
maunium.net/go/gomuks/ui.(*RoomView).filterMediaOnly(...)
        /home//git/gomuks/ui/room-view.go:456
maunium.net/go/gomuks/ui.(*RoomView).findMessage(0xc000d1ba40, 0xc0012cb830, 0xc0040bfd00, 0xc0040bfc20, 0x3)
        /home//git/gomuks/ui/room-view.go:473 +0xeb
maunium.net/go/gomuks/ui.(*RoomView).SelectPrevious(0xc000d1ba40)
        /home//git/gomuks/ui/room-view.go:523 +0xa7
maunium.net/go/gomuks/ui.(*RoomView).OnKeyEvent(0xc000d1ba40, 0xea2720, 0xc000acda80, 0x1392d80)
        /home//git/gomuks/ui/room-view.go:352 +0xb4
maunium.net/go/mauview.(*Box).OnKeyEvent(0xc000185810, 0xea2720, 0xc000acda80, 0x7f56268f22b8)
        /home//go/pkg/mod/maunium.net/go/mauview@v0.1.1/box.go:196 +0x5a
maunium.net/go/mauview.(*Flex).OnKeyEvent(...)
        /home//go/pkg/mod/maunium.net/go/mauview@v0.1.1/flex.go:116
maunium.net/go/gomuks/ui.(*MainView).OnKeyEvent(0xc00024e6e0, 0xea2720, 0xc000acda80, 0x0)
        /home//git/gomuks/ui/view-main.go:204 +0x1d2
maunium.net/go/mauview.(*Application).Start(0xc0003b9200, 0x0, 0x0)
        /home//go/pkg/mod/maunium.net/go/mauview@v0.1.1/application.go:150 +0x3c1
maunium.net/go/gomuks/ui.(*GomuksUI).Start(0xc0004f1380, 0xcbba40, 0xc0004f1350)
        /home//git/gomuks/ui/ui.go:73 +0x2f
main.(*Gomuks).Start(0xc0004f1350)
        /home//git/gomuks/gomuks.go:115 +0x11c
main.main()
        /home//git/gomuks/main.go:83 +0x575
```
