### PR TITLE
Update placeholder on StateEncryption event

### DIFF
--- a/interface/ui.go
+++ b/interface/ui.go
@@ -68,6 +68,7 @@ type RoomView interface {
 
 	SetCompletions(completions []string)
 	SetTyping(users []id.UserID)
+	SetEncrypted()
 	UpdateUserList()
 
 	AddEvent(evt *muksevt.Event) Message

--- a/matrix/matrix.go
+++ b/matrix/matrix.go
@@ -353,6 +353,7 @@ func (c *Container) OnLogin() {
 			}
 		})
 		c.syncer.OnEventType(event.EventEncrypted, c.HandleEncrypted)
+		c.syncer.OnEventType(event.StateEncryption, c.HandleEncryption)
 	} else {
 		c.syncer.OnEventType(event.EventEncrypted, c.HandleEncryptedUnsupported)
 	}
@@ -595,6 +596,17 @@ func (c *Container) HandleEncrypted(source mautrix.EventSource, mxEvent *event.E
 	} else {
 		c.HandleMessage(source, evt)
 	}
+}
+
+func (c *Container) HandleEncryption(source mautrix.EventSource, mxEvent *event.Event) {
+
+	roomView := c.ui.MainView().GetRoom(mxEvent.RoomID)
+	if roomView == nil {
+		debug.Printf("Failed to handle event %v: No room view found.", mxEvent)
+		return
+	}
+	roomView.SetEncrypted()
+	debug.Printf("[Crypto/Debug] Processed encryption event %s of type %s", mxEvent.ID, mxEvent.Type.String())
 }
 
 // HandleMessage is the event handler for the m.room.message timeline event.

--- a/ui/room-view.go
+++ b/ui/room-view.go
@@ -126,7 +126,7 @@ func NewRoomView(parent *MainView, room *rooms.Room) *RoomView {
 		SetPressKeyDownAtEndFunc(view.EditNext)
 
 	if room.Encrypted {
-		view.input.SetPlaceholder("Send an encrypted message...")
+		view.SetEncrypted()
 	}
 
 	view.topic.
@@ -449,6 +449,10 @@ func (view *RoomView) SetEditing(evt *muksevt.Event) {
 	}
 	view.status.SetText(view.GetStatus())
 	view.input.SetCursorOffset(-1)
+}
+
+func (view *RoomView) SetEncrypted() {
+	view.input.SetPlaceholder("Send an encrypted message...")
 }
 
 type findFilter func(evt *muksevt.Event) bool


### PR DESCRIPTION
There was no way to see in gomuks that a room became encrypted. Now the placeholder of the input box of the room gets updated when a `StateEncryption` event is received. ﻿

I really don't know if this is the best way to do it as I just recently started to look at your codebase, so I'm waiting for your suggestions.
