### PR TITLE
Mark private chat as direct

### DIFF
--- a/ui/commands.go
+++ b/ui/commands.go
@@ -552,6 +552,7 @@ func cmdPrivateMessage(cmd *Command) {
 	req := &mautrix.ReqCreateRoom{
 		Preset: "trusted_private_chat",
 		Invite: invites,
+		IsDirect: true,
 	}
 	room, err := cmd.Matrix.CreateRoom(req)
 	if err != nil {


### PR DESCRIPTION
That means direct as in direct messaging.

See also:

- https://matrix.org/docs/spec/client_server/latest#post-matrix-client-r0-createroom
- https://matrix.org/docs/spec/client_server/latest#module-dm
- https://godoc.org/maunium.net/go/mautrix#ReqCreateRoom

fixes #259