### PR TITLE
fix index error in fuzzy search

### DIFF
--- a/ui/fuzzy-search-modal.go
+++ b/ui/fuzzy-search-modal.go
@@ -110,6 +110,7 @@ func (fs *FuzzySearchModal) changeHandler(str string) {
 		}
 		//fs.parent.parent.Render()
 		fs.results.Highlight(strconv.Itoa(fs.matches[0].OriginalIndex))
+		fs.selected = 0
 		fs.results.ScrollToBeginning()
 	} else {
 		fs.results.Clear()


### PR DESCRIPTION
`fs.selected` does not get reset to 0 when the search text is cleared, which causes the wrong room to be selected or an index error.

Steps to reproduce:

1. Open fuzzy search and enter a search term which return many matching rooms.
2. Hit tab N times. (`fs.selected` == N)
3. Clear the search text without selecting a room and enter search term which returns 1 matching room.
4. `fs.selected` is still N even though there is only 1 result.  Hit enter to get an exception.

```
[evan@blackbox gomuks] gomuks 
panic: runtime error: index out of range [1] with length 1 [recovered]
	panic: runtime error: index out of range [1] with length 1 [recovered]
	panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
maunium.net/go/gomuks/debug.Recover()
	/home/evan/resources/gomuks/debug/debug.go:109 +0x94
panic(0xe635a0, 0xc00e066ba0)
	/usr/lib/go-1.14/src/runtime/panic.go:969 +0x166
maunium.net/go/mauview.(*Application).Start.func1(0xc00019d1a0)
	/home/evan/resources/go/pkg/mod/maunium.net/go/mauview@v0.1.2/application.go:104 +0x82
panic(0xe635a0, 0xc00e066ba0)
	/usr/lib/go-1.14/src/runtime/panic.go:969 +0x166
maunium.net/go/gomuks/ui.(*FuzzySearchModal).OnKeyEvent(0xc02327b100, 0x11a0e60, 0xc0235e46c0, 0x7f973a019228)
	/home/evan/resources/gomuks/ui/fuzzy-search-modal.go:148 +0x696
maunium.net/go/gomuks/ui.(*MainView).OnKeyEvent(0xc000475760, 0x11a0e60, 0xc0235e46c0, 0x0)
	/home/evan/resources/gomuks/ui/view-main.go:170 +0x3ca
maunium.net/go/mauview.(*Application).Start(0xc00019d1a0, 0x0, 0x0)
	/home/evan/resources/go/pkg/mod/maunium.net/go/mauview@v0.1.2/application.go:155 +0x3c1
maunium.net/go/gomuks/ui.(*GomuksUI).Start(0xc0004b32f0, 0xf83518, 0xc0004b32c0)
	/home/evan/resources/gomuks/ui/ui.go:75 +0x2f
main.(*Gomuks).Start(0xc0004b32c0)
	/home/evan/resources/gomuks/gomuks.go:115 +0x11c
main.main()
	/home/evan/resources/gomuks/main.go:83 +0x575
```