### PR TITLE
Add NewLineByDefault toggle

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -52,6 +52,7 @@ type UserPreferences struct {
 	DisableDownloads     bool `yaml:"disable_downloads"`
 	DisableNotifications bool `yaml:"disable_notifications"`
 	DisableShowURLs      bool `yaml:"disable_show_urls"`
+	NewLineByDefault     bool `yaml:"new_line_by_default"`
 }
 
 // Config contains the main config of gomuks.

--- a/ui/commands.go
+++ b/ui/commands.go
@@ -698,6 +698,7 @@ var toggleMsg = map[string]ToggleMessage{
 	"notifications": SimpleToggleMessage("desktop notifications"),
 	"unverified":    SimpleToggleMessage("sending messages to unverified devices"),
 	"showurls":      SimpleToggleMessage("show URLs in text format"),
+	"newline":	 SimpleToggleMessage("use <enter> to create new line and <alt+enter> to send"),
 }
 
 func makeUsage() string {
@@ -742,6 +743,8 @@ func cmdToggle(cmd *Command) {
 			val = &cmd.Config.SendToVerifiedOnly
 		case "showurls":
 			val = &cmd.Config.Preferences.DisableShowURLs
+		case "newline":
+			val = &cmd.Config.Preferences.NewLineByDefault
 		default:
 			cmd.Reply("Unknown toggle %s. Use /toggle without arguments for a list of togglable things.", thing)
 			return

--- a/ui/room-view.go
+++ b/ui/room-view.go
@@ -374,7 +374,7 @@ func (view *RoomView) OnKeyEvent(event mauview.KeyEvent) bool {
 		msgView.AddScrollOffset(-msgView.Height() / 2)
 		return true
 	case tcell.KeyEnter:
-		if event.Modifiers()&tcell.ModShift == 0 && event.Modifiers()&tcell.ModCtrl == 0 {
+		if (event.Modifiers()&tcell.ModShift == 0 && event.Modifiers()&tcell.ModCtrl == 0) == (view.config.Preferences.NewLineByDefault) {
 			view.InputSubmit(view.input.GetText())
 			return true
 		}


### PR DESCRIPTION
This adds an option to use <Enter> to create a new line, and <Alt+Enter> to send a message, essentially swapping <Enter> and <Alt+Enter>.

This allows users to compose multi-line messages easily and also allow pasting multi-line messages from the clipboard.