### PR TITLE
ui: use ColorDefault where appropriate

### DIFF
--- a/ui/fuzzy-search-modal.go
+++ b/ui/fuzzy-search-modal.go
@@ -58,7 +58,7 @@ func NewFuzzySearchModal(mainView *MainView, width int, height int) *FuzzySearch
 	fs.results = mauview.NewTextView().SetRegions(true)
 	fs.search = mauview.NewInputArea().
 		SetChangedFunc(fs.changeHandler).
-		SetTextColor(tcell.ColorWhite).
+		SetTextColor(tcell.ColorDefault).
 		SetBackgroundColor(tcell.ColorDarkCyan)
 	fs.search.Focus()
 

--- a/ui/help-modal.go
+++ b/ui/help-modal.go
@@ -76,7 +76,8 @@ func NewHelpModal(parent *MainView) *HelpModal {
 	text := mauview.NewTextView().
 		SetText(helpText).
 		SetScrollable(true).
-		SetWrap(false)
+		SetWrap(false).
+		SetTextColor(tcell.ColorDefault)
 
 	box := mauview.NewBox(text).
 		SetBorder(true).

--- a/ui/member-list.go
+++ b/ui/member-list.go
@@ -107,7 +107,7 @@ func (ml *MemberList) Update(data map[id.UserID]*rooms.Member, levels *event.Pow
 
 func (ml *MemberList) Draw(screen mauview.Screen) {
 	width, _ := screen.Size()
-	sigilStyle := tcell.StyleDefault.Background(tcell.ColorGreen).Foreground(tcell.ColorWhite)
+	sigilStyle := tcell.StyleDefault.Background(tcell.ColorGreen).Foreground(tcell.ColorDefault)
 	for y, member := range ml.list {
 		if member.Sigil != ' ' {
 			screen.SetCell(0, y, sigilStyle, member.Sigil)

--- a/ui/room-list.go
+++ b/ui/room-list.go
@@ -96,8 +96,8 @@ func NewRoomList(parent *MainView) *RoomList {
 
 		scrollOffset: 0,
 
-		mainTextColor:           tcell.ColorWhite,
-		selectedTextColor:       tcell.ColorWhite,
+		mainTextColor:           tcell.ColorDefault,
+		selectedTextColor:       tcell.ColorDefault,
 		selectedBackgroundColor: tcell.ColorDarkGreen,
 	}
 	for _, tag := range list.tags {

--- a/ui/room-view.go
+++ b/ui/room-view.go
@@ -118,6 +118,7 @@ func NewRoomView(parent *MainView, room *rooms.Room) *RoomView {
 	view.Room.SetPostLoad(view.loadTyping)
 
 	view.input.
+		SetTextColor(tcell.ColorDefault).
 		SetBackgroundColor(tcell.ColorDefault).
 		SetPlaceholder("Send a message...").
 		SetPlaceholderTextColor(tcell.ColorGray).
@@ -130,7 +131,7 @@ func NewRoomView(parent *MainView, room *rooms.Room) *RoomView {
 	}
 
 	view.topic.
-		SetTextColor(tcell.ColorWhite).
+		SetTextColor(tcell.ColorDefault).
 		SetBackgroundColor(tcell.ColorDarkGreen)
 
 	view.status.SetBackgroundColor(tcell.ColorDimGray)

--- a/ui/verification-modal.go
+++ b/ui/verification-modal.go
@@ -106,7 +106,7 @@ func NewVerificationModal(mainView *MainView, device *crypto.DeviceIdentity, tim
 
 	vm.inputBar = mauview.NewInputField().
 		SetBackgroundColor(tcell.ColorDefault).
-		SetPlaceholderTextColor(tcell.ColorWhite)
+		SetPlaceholderTextColor(tcell.ColorDefault)
 
 	flex := mauview.NewFlex().
 		SetDirection(mauview.FlexRow).
@@ -163,7 +163,7 @@ func (vm *VerificationModal) VerifySASMatch(device *crypto.DeviceIdentity, data 
 			"same %s as below, then type \"yes\" to\n"+
 			"accept, or \"no\" to reject", typeName))
 	vm.inputBar.
-		SetTextColor(tcell.ColorWhite).
+		SetTextColor(tcell.ColorDefault).
 		SetBackgroundColor(tcell.ColorDarkCyan).
 		SetPlaceholder("Type \"yes\" or \"no\"").
 		Focus()


### PR DESCRIPTION
This is not the configurable colors change as was requested in issue #23 but at least it makes gomuks usable with black on white terminal color schemes, and should not impact white on black looks significantly.

There's at least still an issue with /help box's title as boxes in mauview don't have ForegroundColor property.

![20210404@011910](https://user-images.githubusercontent.com/7458476/113492930-e70fee00-94e3-11eb-8561-2a4c316d02f7.png)

