### PR TITLE
Added 'exit' command to quit gomuks

### DIFF
--- a/ui/commands.go
+++ b/ui/commands.go
@@ -444,6 +444,10 @@ func cmdQuit(cmd *Command) {
 	cmd.Gomuks.Stop(true)
 }
 
+func cmdExit(cmd *Command) {
+	cmd.Gomuks.Stop(true)
+}
+
 func cmdClearCache(cmd *Command) {
 	cmd.Config.Clear()
 	cmd.Gomuks.Stop(false)


### PR DESCRIPTION
Typing /exit should now quit gomuks. I have not tested it yet but it should it work. (Just copied and pasted to code for the Quit command)