### PR TITLE
Added notify_openbsd.go to the notification library so that notifications will be available on OpenBSD systems as well

### DIFF
--- a/lib/notification/notify_openbsd.go
+++ b/lib/notification/notify_openbsd.go
@@ -1,5 +1,3 @@
-// +build !linux,!darwin,!windows,!openbsd
-
 // gomuks - A terminal Matrix client written in Go.
 // Copyright (C) 2020 Tulir Asokan
 //
@@ -18,6 +16,17 @@
 
 package notification
 
+import "os/exec"
+
 func Send(title, text string, critical, sound bool) error {
-	return nil
+	args := []string{"-a", "gomuks"}
+	if !critical {
+		args = append(args, "-u", "low")
+	}
+	// 	if iconPath {
+	// 		args = append(args, "-i", iconPath)
+	// 	}
+	args = append(args, title, text)
+
+	return exec.Command("notify-send", args...).Run()
 }


### PR DESCRIPTION
I use `gomuks` on a laptop running OpenBSD with `notify-send`, but I noticed that the SendNotification function was using the `lib/notification/notify_unsupported.go` library instead of the `lib/notification/notify_linux.go` library, which should work fine for OpenBSD, minus the reliance on `paplay`, which is not available in base on OpenBSD.

I created `lib/notification/notify_openbsd.go` using `notify_linux.go` as a template. It's the same thing, essentially, minus any notification sounds since OpenBSD has no way to play .ogg files in base and I don't want to create extra dependencies.