### PR TITLE
Add toggle for timestamps

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -43,6 +43,7 @@ type AuthCache struct {
 type UserPreferences struct {
 	HideUserList         bool `yaml:"hide_user_list"`
 	HideRoomList         bool `yaml:"hide_room_list"`
+	HideTimeStamp        bool `yaml:"hide_time_stamp"`
 	BareMessageView      bool `yaml:"bare_message_view"`
 	DisableImages        bool `yaml:"disable_images"`
 	DisableTypingNotifs  bool `yaml:"disable_typing_notifs"`

--- a/ui/commands.go
+++ b/ui/commands.go
@@ -703,6 +703,7 @@ func (nkm NewlineKeybindMessage) Name() string {
 var toggleMsg = map[string]ToggleMessage{
 	"rooms":         HideMessage("Room list sidebar"),
 	"users":         HideMessage("User list sidebar"),
+	"timestamp":     HideMessage("Message timestamp"),
 	"baremessages":  SimpleToggleMessage("bare message view"),
 	"images":        SimpleToggleMessage("image rendering"),
 	"typingnotif":   SimpleToggleMessage("typing notifications"),
@@ -738,6 +739,8 @@ func cmdToggle(cmd *Command) {
 			val = &cmd.Config.Preferences.HideRoomList
 		case "users":
 			val = &cmd.Config.Preferences.HideUserList
+		case "timestamp":
+			val = &cmd.Config.Preferences.HideTimeStamp
 		case "baremessages":
 			val = &cmd.Config.Preferences.BareMessageView
 		case "images":

--- a/ui/message-view.go
+++ b/ui/message-view.go
@@ -160,7 +160,11 @@ func (view *MessageView) AddMessage(ifcMessage ifc.Message, direction MessageDir
 	width := view.width()
 	bare := view.config.Preferences.BareMessageView
 	if !bare {
-		width -= view.TimestampWidth + TimestampSenderGap + view.widestSender() + SenderMessageGap
+		if view.config.Preferences.HideTimeStamp {
+			width -= TimestampSenderGap + view.widestSender() + SenderMessageGap
+		} else {
+			width -= view.TimestampWidth + TimestampSenderGap + view.widestSender() + SenderMessageGap
+		}
 	}
 	message.CalculateBuffer(view.config.Preferences, width)
 
@@ -323,7 +327,11 @@ func (view *MessageView) recalculateBuffers() {
 	if recalculateMessageBuffers || len(view.messages) != view.prevMsgCount {
 		width := view.width()
 		if !prefs.BareMessageView {
-			width -= view.TimestampWidth + TimestampSenderGap + view.widestSender() + SenderMessageGap
+			if prefs.HideTimeStamp {
+				width -= TimestampSenderGap + view.widestSender() + SenderMessageGap
+			} else {
+				width -= view.TimestampWidth + TimestampSenderGap + view.widestSender() + SenderMessageGap
+			}
 		}
 		view.msgBuffer = []*messages.UIMessage{}
 		view.prevMsgCount = 0
@@ -436,6 +444,9 @@ func (view *MessageView) OnMouseEvent(event mauview.MouseEvent) bool {
 		view.msgBufferLock.RUnlock()
 
 		usernameX := view.TimestampWidth + TimestampSenderGap
+		if !view.config.Preferences.HideTimeStamp {
+			usernameX = TimestampSenderGap
+		}
 		messageX := usernameX + view.widestSender() + SenderMessageGap
 
 		if x >= messageX {
@@ -602,6 +613,9 @@ func (view *MessageView) Draw(screen mauview.Screen) {
 	}
 
 	usernameX := view.TimestampWidth + TimestampSenderGap
+	if view.config.Preferences.HideTimeStamp {
+		usernameX = TimestampSenderGap
+	}
 	messageX := usernameX + view.widestSender() + SenderMessageGap
 
 	bareMode := view.config.Preferences.BareMessageView
@@ -643,7 +657,7 @@ func (view *MessageView) Draw(screen mauview.Screen) {
 			continue
 		}
 
-		if len(msg.FormatTime()) > 0 {
+		if len(msg.FormatTime()) > 0 && !view.config.Preferences.HideTimeStamp {
 			widget.WriteLineSimpleColor(screen, msg.FormatTime(), 0, line, msg.TimestampColor())
 		}
 		// TODO hiding senders might not be that nice after all, maybe an option? (disabled for now)


### PR DESCRIPTION
This adds a toggle so timestamps in message rooms can be hidden
Screenshot with timestamps disabled:
![image](https://user-images.githubusercontent.com/7910815/129704826-5244e6d2-aa00-4cc4-bf55-3c3597442114.png)
