### PR TITLE
Draft: Add support for reading message from external editor

### DIFF
--- a/lib/edit/doc.go
+++ b/lib/edit/doc.go
@@ -1,0 +1,2 @@
+// Package edit contains a simple script to edit text with external editor.
+package edit

--- a/lib/edit/edit_xdg.go
+++ b/lib/edit/edit_xdg.go
@@ -1,0 +1,42 @@
+// gomuks - A terminal Matrix client written in Go.
+// Copyright (C) 2020 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package edit
+
+import (
+	"os"
+	"os/exec"
+	"io/ioutil"
+)
+
+const file = "/tmp/gomuks-draft.md"
+
+func GetText(text string) string {
+	visual, exists := os.LookupEnv("VISUAL")
+	if ! exists {
+		visual = "vi"
+	}
+
+	f, _ := os.Create("/tmp/gomuks-draft.md")
+	f.WriteString(text)
+
+	exec.Command(os.Getenv("TERM"), visual, file).Run()
+
+	content, _ := ioutil.ReadFile(file)
+
+	return string(content)
+}
+

--- a/ui/room-view.go
+++ b/ui/room-view.go
@@ -39,6 +39,7 @@ import (
 	"maunium.net/go/gomuks/debug"
 	"maunium.net/go/gomuks/interface"
 	"maunium.net/go/gomuks/lib/open"
+	"maunium.net/go/gomuks/lib/edit"
 	"maunium.net/go/gomuks/lib/util"
 	"maunium.net/go/gomuks/matrix/muksevt"
 	"maunium.net/go/gomuks/matrix/rooms"
@@ -374,6 +375,9 @@ func (view *RoomView) OnKeyEvent(event mauview.KeyEvent) bool {
 			view.InputSubmit(view.input.GetText())
 			return true
 		}
+	case tcell.KeyCtrlE:
+		view.InputSubmit(edit.GetText(view.input.GetText()))
+		return true
 	}
 	return view.input.OnKeyEvent(event)
 }


### PR DESCRIPTION
Closes #311. Inital implementation, uses another instance of `$TERM`, which doesn't work always and which isn't the thing we want.

Suggestions on how to make `$EDITOR` take over the screen while editing message are wanted.