### PR TITLE
set topic line to the room name, when topic is empty

### DIFF
--- a/matrix/rooms/room.go
+++ b/matrix/rooms/room.go
@@ -476,6 +476,9 @@ func (room *Room) GetTopic() string {
 		if topicEvt != nil {
 			room.topicCache = topicEvt.Content.AsTopic().Topic
 		}
+		if room.topicCache == "" {
+			room.topicCache = room.NameCache
+		}
 	}
 	return room.topicCache
 }


### PR DESCRIPTION
this is useful when the room list is hidden, so you can still see what room you're in.
might also want to disable this when the room list is enabled, since there's possibly redundant info, though in that case the topic bar would be empty anyway.