### PR TITLE
Add custom keybindings

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -56,6 +56,10 @@ type UserPreferences struct {
 	AltEnterToSend       bool `yaml:"alt_enter_to_send"`
 }
 
+type Keybindings struct {
+	Keybindings map[string]string `yaml:"keybindings,omitempty"`
+}
+
 // Config contains the main config of gomuks.
 type Config struct {
 	UserID      id.UserID   `yaml:"mxid"`
@@ -85,6 +89,7 @@ type Config struct {
 	AuthCache   AuthCache              `yaml:"-"`
 	Rooms       *rooms.RoomCache       `yaml:"-"`
 	PushRules   *pushrules.PushRuleset `yaml:"-"`
+	Keybindings Keybindings			   `yaml:"-"`
 
 	nosave bool
 }
@@ -152,6 +157,7 @@ func (config *Config) LoadAll() {
 	config.LoadAuthCache()
 	config.LoadPushRules()
 	config.LoadPreferences()
+	config.LoadKeybindings()
 	err := config.Rooms.LoadList()
 	if err != nil {
 		panic(err)
@@ -187,6 +193,14 @@ func (config *Config) LoadPreferences() {
 
 func (config *Config) SavePreferences() {
 	config.save("user preferences", config.CacheDir, "preferences.yaml", &config.Preferences)
+}
+
+func (config *Config) LoadKeybindings() {
+	config.load("keybindings", config.Dir, "keybindings.yaml", &config.Keybindings)
+}
+
+func (config *Config) SaveKeybindings() {
+	config.save("keybindings", config.Dir, "keybindings.yaml", &config.Keybindings)
 }
 
 func (config *Config) LoadAuthCache() {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/alecthomas/chroma v0.8.2
 	github.com/disintegration/imaging v1.6.2
 	github.com/gabriel-vasile/mimetype v1.2.0
+	github.com/gdamore/tcell/v2 v2.0.0-dev
 	github.com/kyokomi/emoji/v2 v2.2.8
 	github.com/lithammer/fuzzysearch v1.1.1
 	github.com/lucasb-eyer/go-colorful v1.2.0
@@ -17,6 +18,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0
 	github.com/sasha-s/go-deadlock v0.2.0
 	github.com/zyedidia/clipboard v1.0.3
+	gitlab.com/tslocum/cbind v0.1.2
 	go.etcd.io/bbolt v1.3.5
 	golang.org/x/image v0.0.0-20210220032944-ac19c3e999fb
 	golang.org/x/net v0.0.0-20211020060615-d418f374d309

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/gabriel-vasile/mimetype v1.2.0 h1:A6z5J8OhjiWFV91sQ3dMI8apYu/tvP9keDa
 github.com/gabriel-vasile/mimetype v1.2.0/go.mod h1:6CDPel/o/3/s4+bp6kIbsWATq8pmgOisOPG40CJa6To=
 github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
+github.com/gdamore/tcell/v2 v2.0.0-dev h1:34h4ahbtQZ7ndLnAHAdamYk6eQ5W/piK9Vm5/JiYkfQ=
+github.com/gdamore/tcell/v2 v2.0.0-dev/go.mod h1:vSVL/GV5mCSlPC6thFP5kfOFdM9MGZcalipmpTxTgQA=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
@@ -52,6 +54,7 @@ github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-sqlite3 v1.14.9 h1:10HX2Td0ocZpYEjhilsuo6WWtUqttj2Kb0KtD86/KYA=
@@ -94,6 +97,8 @@ github.com/zyedidia/clipboard v1.0.3 h1:F/nCDVYMdbDWTmY8s8cJl0tnwX32q96IF09JHM14
 github.com/zyedidia/clipboard v1.0.3/go.mod h1:zykFnZUXX0ErxqvYLUFEq7QDJKId8rmh2FgD0/Y8cjA=
 github.com/zyedidia/poller v1.0.1 h1:Tt9S3AxAjXwWGNiC2TUdRJkQDZSzCBNVQ4xXiQ7440s=
 github.com/zyedidia/poller v1.0.1/go.mod h1:vZXJOHGDcuK08GXhF6IAY0ZFd2WcgOR5DOTp84Uk5eE=
+gitlab.com/tslocum/cbind v0.1.2 h1:ptDjO7WeOl1HglprsK18L8I9JeRkmtuBoBBaYw/6/Ow=
+gitlab.com/tslocum/cbind v0.1.2/go.mod h1:HfB7qAhHSZbn1rFK8M9SvSN5NG6ScAg/3h3iE6xdeeI=
 go.etcd.io/bbolt v1.3.5 h1:XAzx9gjCb0Rxj7EoqcClPD1d5ZBxZJk0jbuoPHenBt0=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -113,11 +118,13 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190626150813-e07cf5db2756/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200413165638-669c56c373c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200501145240-bc7a7d42d5c3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200826173525-f9321e4c35a6/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=

--- a/ui/view-main.go
+++ b/ui/view-main.go
@@ -38,6 +38,9 @@ import (
 	"maunium.net/go/gomuks/matrix/rooms"
 	"maunium.net/go/gomuks/ui/widget"
 	"maunium.net/go/mautrix/pushrules"
+
+	"gitlab.com/tslocum/cbind"
+	tcell_v2 "github.com/gdamore/tcell/v2"
 )
 
 type MainView struct {
@@ -163,11 +166,36 @@ func (view *MainView) OpenSyncingModal() ifc.SyncingModal {
 	return modal
 }
 
+func (view *MainView) PreviousRoomCallback() {
+	view.SwitchRoom(view.roomList.Previous())
+}
+
+func (view *MainView) NextRoomCallback() {
+	view.SwitchRoom(view.roomList.Next())
+}
+
 func (view *MainView) OnKeyEvent(event mauview.KeyEvent) bool {
 	view.BumpFocus(view.currentRoom)
 
 	if view.modal != nil {
 		return view.modal.OnKeyEvent(event)
+	}
+
+	key_map := map[string]func() {
+		"Ctrl+P": view.PreviousRoomCallback,
+		"Ctrl+N": view.NextRoomCallback,
+	}
+
+	key_string, _ := cbind.Encode(
+		tcell_v2.ModMask(event.Modifiers()),
+		tcell_v2.Key(event.Key()),
+		event.Rune())
+
+	callback, _ := key_map[key_string]
+
+	if callback != nil {
+		callback()
+		return true
 	}
 
 	k := event.Key()


### PR DESCRIPTION
Hi and thanks for doing gomuks!
This PR is an approach to add customizable keybindings; this has been discussed in several related issues like #69 #70 #112 and #128. This is just a proposal, I'd love to improve this PR if you have any suggestions.

I've never written much golang code before and was mainly adapting what I already saw, so please let me know if you spot anything that's just bad practice.

This PR
- adds a keybinding config, that is read from `$HOME/.config/gomuks/keybindings.yaml`
- uses `cbind`'s `Encode` to translate key(combination)s to strings
- adds some callbacks to `ui/view-main.go`

Also
- Key combinations or callbacks that cannot be found in the maps will be ignored and handled as usual by gomuks
- I choose the versions of the added dependencies to be compatible i.e. with `go-runewidth`, though I'm not particularly happy I had to add `tcell/v2`, not sure if that's a problem. To me, the convenience of using `Encode` seemed to be worth it.
- I'm also not sure if the callbacks should stay in `ui/view-main.go` or if there would be a more suitable place. I could also imagine a separate keybindings struct that the main view "registers" to.
- Names of callbacks or mapping strings can of course be changed to anything more suitable.

Would be happy to hear your thoughts. My `keybindings.yaml` looks like this:
``` yaml
keybindings:
  "Ctrl+P": "previous_room"
  "Ctrl+N": "next_room"
  "Alt+g": "goto_room"
  "Alt+a": "active_room"
  "Alt+b": "word_left"
  "Alt+f": "word_right"
  "Ctrl+B": "char_left"
  "Ctrl+F": "char_right"
  "Alt+j": "scroll_down"
  "Alt+k": "scroll_up"
  "Ctrl+D": "remove_char"
  "Ctrl+W": "remove_previous_word"
  "Alt+d": "remove_next_word"
  "Ctrl+A": "move_to_beginning"
  "Ctrl+E": "move_to_end"
  "Ctrl+U": "kill_to_beginning"
  "Ctrl+K": "kill_to_end"
```