### PR TITLE
Allow emojis in reactions

### DIFF
--- a/ui/room-view.go
+++ b/ui/room-view.go
@@ -734,6 +734,9 @@ func (view *RoomView) Redact(eventID id.EventID, reason string) {
 
 func (view *RoomView) SendReaction(eventID id.EventID, reaction string) {
 	defer debug.Recover()
+	if !view.config.Preferences.DisableEmojis {
+		reaction = emoji.Sprint(reaction)
+	}
 	debug.Print("Reacting to", eventID, "in", view.Room.ID, "with", reaction)
 	eventID, err := view.parent.matrix.SendEvent(&muksevt.Event{
 		Event: &event.Event{


### PR DESCRIPTION
Copy-pasted the extract from `SendMessageHTML` that does the same thing. **This patch has not been tested yet** as I do not have a Go development environment accessible currently. I will do so in the upcoming days.

My doubts would be about whether this transformation should come before or after the debug printing. Any opinions?

Thanks for gomuks, it has been really enjoyable to use!