### PR TITLE
Display inline code in messages

### DIFF
--- a/ui/messages/html/parser.go
+++ b/ui/messages/html/parser.go
@@ -139,6 +139,11 @@ func (parser *htmlParser) basicFormatToEntity(node *html.Node) Entity {
 		entity.AdjustStyle(AdjustStyleStrikethrough, AdjustStyleReasonNormal)
 	case "u", "ins":
 		entity.AdjustStyle(AdjustStyleUnderline, AdjustStyleReasonNormal)
+	case "code":
+		bgColor := tcell.ColorDarkSlateGray
+		fgColor := tcell.ColorWhite
+		entity.AdjustStyle(AdjustStyleBackgroundColor(bgColor), AdjustStyleReasonNormal)
+		entity.AdjustStyle(AdjustStyleTextColor(fgColor), AdjustStyleReasonNormal)
 	case "font", "span":
 		fgColor, ok := parser.parseColor(node, "data-mx-color", "color")
 		if ok {
@@ -357,7 +362,7 @@ func (parser *htmlParser) tagNodeToEntity(node *html.Node) Entity {
 		return parser.headerToEntity(node)
 	case "br":
 		return NewBreakEntity()
-	case "b", "strong", "i", "em", "s", "strike", "del", "u", "ins", "font", "span":
+	case "b", "strong", "i", "em", "s", "strike", "del", "u", "ins", "font", "span", "code":
 		return parser.basicFormatToEntity(node)
 	case "a":
 		return parser.linkToEntity(node)


### PR DESCRIPTION
The TextColor is also set to make sure it is readable with black on white themes.

![2022-04-10-195353_505x51_scrot](https://user-images.githubusercontent.com/23519418/162637753-f5b45d33-ea47-4f55-9c87-c344ac75b63c.png)

Fixes #134
