### PR TITLE
Command.RawArgs has surrounding whitespace trimmed

### DIFF
--- a/ui/command-processor.go
+++ b/ui/command-processor.go
@@ -201,7 +201,7 @@ func (ch *CommandProcessor) ParseCommand(roomView *RoomView, text string) *Comma
 	args := split[1:]
 	var rawArgs string
 	if len(text) > len(command)+1 {
-		rawArgs = text[len(command)+1:]
+		rawArgs = strings.TrimSpace(text[len(command)+1:])
 	}
 	return &Command{
 		gomuksPointerContainer: ch.gomuksPointerContainer,


### PR DESCRIPTION
Hello tulir and gomuks contributors,

This PR trims the extreme left and right whitespace around `command.RawArgs`, which, among other things, is used as the path of the file in the `/upload` command. I found the following behavior when using gomuks in macos: in the terminal, you're allowed to drag and drop a file from the desktop or "finder", and terminal pastes the absolute path, followed by a space. This caused gomuks on the latest master branch to throw a `file not found` exception, while taking care to delete the extra space character succeeds of course (steps to reproduce: in any room, type `/upload /correct/path/to/file` followed by a space, ` `. This should fail and throw a "file not found" error). 

[`strings.TrimSpace`](https://pkg.go.dev/strings#TrimSpace) only trims space on the extreme left and right. Since `strings.Fields` also trims this whitespace as well as whitespace between the words I think it is reasonable to trim whitespace for `command.RawArgs`. As far as I can tell, this doesn't break any other commands that `RawArgs` is used for.

Thank you, am looking forward to your input on this.