### PR TITLE
Add support to upload multiple files at once

### DIFF
--- a/lib/filepicker/filepicker.go
+++ b/lib/filepicker/filepicker.go
@@ -24,6 +24,7 @@ import (
 )
 
 var zenity string
+var sep = "|"
 
 func init() {
 	zenity, _ = exec.LookPath("zenity")
@@ -33,17 +34,18 @@ func IsSupported() bool {
 	return len(zenity) > 0
 }
 
-func Open() (string, error) {
-	cmd := exec.Command(zenity, "--file-selection")
+func Open() ([]string, error) {
+	cmd := exec.Command(zenity, "--file-selection", "--multiple", "--separator", sep)
 	var output bytes.Buffer
 	cmd.Stdout = &output
 	err := cmd.Run()
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
-			return "", nil
+			return nil, nil
 		}
-		return "", err
+		return nil, err
 	}
-	return strings.TrimSpace(output.String()), nil
+
+	return strings.Split(strings.TrimSpace(output.String()), sep), nil
 }

--- a/ui/commands.go
+++ b/ui/commands.go
@@ -259,15 +259,15 @@ func cmdDownload(cmd *Command) {
 }
 
 func cmdUpload(cmd *Command) {
-	var path string
+	var paths []string
 	var err error
 	if len(cmd.Args) == 0 {
 		if filepicker.IsSupported() {
-			path, err = filepicker.Open()
+			paths, err = filepicker.Open()
 			if err != nil {
 				cmd.Reply("Failed to open file picker: %v", err)
 				return
-			} else if len(path) == 0 {
+			} else if len(paths) == 0 {
 				cmd.Reply("File picking cancelled")
 				return
 			}
@@ -276,14 +276,16 @@ func cmdUpload(cmd *Command) {
 			return
 		}
 	} else {
-		path, err = filepath.Abs(cmd.RawArgs)
+		paths, err = filepath.Glob(cmd.RawArgs)
 		if err != nil {
-			cmd.Reply("Failed to get absolute path: %v", err)
+			cmd.Reply("Failed to glob path: %v", err)
 			return
 		}
 	}
 
-	go cmd.Room.SendMessageMedia(path)
+	for _, path := range paths {
+		go cmd.Room.SendMessageMedia(path)
+	}
 }
 
 func cmdOpen(cmd *Command) {


### PR DESCRIPTION
The /upload <filepath> commands extended to support globs, as proposed
in #332

The upload filepicker has been extended to support uploading multiple
files at once.