### PR TITLE
WIP: add /keys command based on /help

### DIFF
--- a/ui/command-processor.go
+++ b/ui/command-processor.go
@@ -129,6 +129,7 @@ func NewCommandProcessor(parent *MainView) *CommandProcessor {
 
 			"id":         cmdID,
 			"help":       cmdHelp,
+			"keys":       cmdKeys,
 			"me":         cmdMe,
 			"quit":       cmdQuit,
 			"clearcache": cmdClearCache,

--- a/ui/commands.go
+++ b/ui/commands.go
@@ -548,6 +548,11 @@ func cmdHelp(cmd *Command) {
 	view.ShowModal(NewHelpModal(view))
 }
 
+func cmdKeys(cmd *Command) {
+	view := cmd.MainView
+	view.ShowModal(NewKeysModal(view))
+}
+
 func cmdLeave(cmd *Command) {
 	err := cmd.Matrix.LeaveRoom(cmd.Room.MxRoom().ID)
 	debug.Print("Leave room error:", err)

--- a/ui/help-modal.go
+++ b/ui/help-modal.go
@@ -9,6 +9,7 @@ import (
 
 const helpText = `# General
 /help           - Show this help dialog.
+/keys           - Show keyboard shortcuts.
 /quit           - Quit gomuks.
 /clearcache     - Clear cache and quit gomuks.
 /logout         - Log out of Matrix.
@@ -91,6 +92,50 @@ func NewHelpModal(parent *MainView) *HelpModal {
 	box := mauview.NewBox(text).
 		SetBorder(true).
 		SetTitle("Help").
+		SetBlurCaptureFunc(func() bool {
+			hm.parent.HideModal()
+			return true
+		})
+	box.Focus()
+
+	hm.FocusableComponent = mauview.FractionalCenter(box, 42, 10, 0.5, 0.5)
+
+	return hm
+}
+
+const keysText = `Note: Ctrl and Alt are interchangeable in most keybindings, but the other one may not work depending on your terminal emulator.
+
+SHORTCUTS:
+Ctrl+↑, Ctrl+↓ - Switch rooms
+PgUp, PgDown   - Scroll chat (page)
+Ctrl+K         - Jump to room, type part of a room's name, then TAB and ENTER to navigate and select room
+Ctrl+L         - Plaintext mode
+Alt+Enter      - Newline
+Tab            - Autocompletion (emojis, usernames, room aliases and commands)
+
+EDITING MESSAGES:
+↑ and ↓ can be used at the start and end of the input area to jump to edit the previous or next message respectively.
+
+SELECTING MESSAGES:
+After using commands that require selecting messages (e.g. /reply and /redact), you can move the selection with ↑ and ↓ confirm with ENTER
+
+MOUSE:
+Click               - select message (for commands such as /reply that act on a message)
+CTRL+CLICK on image - open in your default image viewer (xdg-open)
+Click on a username - insert a mention of that user into the composer.`
+
+func NewKeysModal(parent *MainView) *HelpModal {
+	hm := &HelpModal{parent: parent}
+
+	text := mauview.NewTextView().
+		SetText(keysText).
+		SetScrollable(true).
+		SetWrap(false).
+		SetTextColor(tcell.ColorDefault)
+
+	box := mauview.NewBox(text).
+		SetBorder(true).
+		SetTitle("Keyboard shortcuts").
 		SetBlurCaptureFunc(func() bool {
 			hm.parent.HideModal()
 			return true


### PR DESCRIPTION
Based on discussion in #327, I spun up this pr for `/keys` which lists the keyboard shortcuts based on [this page](https://docs.mau.fi/gomuks/shortcuts.html) in the manual, and based on the `/help` dialog box. I'm looking for help on this, both tips on formatting or language used, and any changes to the view box. Especially interested if SetWrap should be set to true or false, or if the name of the command should be changed. Thank you

![image](https://user-images.githubusercontent.com/49931356/172528985-609948ad-1625-4f52-92ce-35d9131d767b.png)
