### PR TITLE
Fallback to "plaintext" lexer in codeblock parser

### DIFF
--- a/ui/messages/html/parser.go
+++ b/ui/messages/html/parser.go
@@ -292,7 +292,7 @@ func tokenToTextEntity(style *chroma.Style, token *chroma.Token) *TextEntity {
 func (parser *htmlParser) syntaxHighlight(text, language string) Entity {
 	lexer := lexers.Get(strings.ToLower(language))
 	if lexer == nil {
-		return nil
+		lexer = lexers.Get("plaintext")
 	}
 	iter, err := lexer.Tokenise(nil, text)
 	if err != nil {


### PR DESCRIPTION
This avoids "malformed message" in the timeline when the lexer for a given language is not found.
