### PR TITLE
Fix mangled newlines in some code blocks

### DIFF
--- a/ui/messages/html/parser.go
+++ b/ui/messages/html/parser.go
@@ -305,27 +305,19 @@ func (parser *htmlParser) syntaxHighlight(text, language string) Entity {
 
 	var children []Entity
 	for _, token := range tokens {
-		if token.Value == "\n" {
-			children = append(children, NewBreakEntity())
-
-		} else if token.Type.String() == "CommentSingle" {
-			children = append(children, tokenToTextEntity(style, &token))
-			children = append(children, NewBreakEntity())
-
-		} else if token.Type.String() == "CommentMultiline" {
-			lines := strings.Split(token.Value, "\n")
-			for i, line := range lines {
-				t := token.Clone()
-				t.Value = line
-				children = append(children, tokenToTextEntity(style, &t))
-
-				if i < len(lines)-1 {
-					children = append(children, NewBreakEntity())
-				}
+		lines := strings.SplitAfter(token.Value, "\n")
+		for _, line := range lines {
+			line_len := len(line)
+			if line_len == 0 {
+				continue
 			}
+			t := token.Clone()
+			t.Value = line
+			children = append(children, tokenToTextEntity(style, &t))
 
-		} else {
-			children = append(children, tokenToTextEntity(style, &token))
+			if line[line_len-1:] == "\n" {
+				children = append(children, NewBreakEntity())
+			}
 		}
 	}
 

--- a/ui/messages/html/parser.go
+++ b/ui/messages/html/parser.go
@@ -312,11 +312,13 @@ func (parser *htmlParser) syntaxHighlight(text, language string) Entity {
 				continue
 			}
 			t := token.Clone()
-			t.Value = line
-			children = append(children, tokenToTextEntity(style, &t))
 
 			if line[line_len-1:] == "\n" {
-				children = append(children, NewBreakEntity())
+				t.Value = line[:line_len-1]
+				children = append(children, tokenToTextEntity(style, &t), NewBreakEntity())
+			} else {
+				t.Value = line
+				children = append(children, tokenToTextEntity(style, &t))
 			}
 		}
 	}


### PR DESCRIPTION
Because some tokens can contain newlines and not only comment tokens, I removed the comments specific code to handle newlines in a more generic way.

#### Before
![2022-10-10-184125_975x737_scrot](https://user-images.githubusercontent.com/23519418/194916067-b180d09d-afb9-435c-815d-e1eca3f809ea.png)

#### After
![2022-10-10-185740_975x722_scrot](https://user-images.githubusercontent.com/23519418/194917732-bc300108-9a91-4c34-b5ae-84230ec0b7e6.png)

#### Before
![2022-10-10-184340_765x527_scrot](https://user-images.githubusercontent.com/23519418/194916071-fd086f8f-0998-4323-bef3-96fc2baebec1.png)

#### After
![2022-10-10-184522_765x527_scrot](https://user-images.githubusercontent.com/23519418/194916074-2152406a-9e02-463e-8aaf-a89767cd57a3.png)

Fixes #274
Fixes #213