### PR TITLE
Preserve newlines in plain text messages

### DIFF
--- a/ui/messages/html/parser.go
+++ b/ui/messages/html/parser.go
@@ -388,8 +388,8 @@ func (parser *htmlParser) tagNodeToEntity(node *html.Node) Entity {
 
 var spaces = regexp.MustCompile("\\s+")
 
-// textToHtmlEntity converts a plain text string into an HtmlEntity while preserving newlines.
-func textToHtmlEntity(text string) Entity {
+// textToHTMLEntity converts a plain text string into an HTML Entity while preserving newlines.
+func textToHTMLEntity(text string) Entity {
 	lines := strings.SplitAfter(text, "\n")
 	if len(lines) == 1 {
 		return NewTextEntity(text)
@@ -416,11 +416,11 @@ func TextToEntity(text string, eventID id.EventID, linkify bool) Entity {
 		return nil
 	}
 	if !linkify {
-		return textToHtmlEntity(text)
+		return textToHTMLEntity(text)
 	}
 	indices := xurls.Strict().FindAllStringIndex(text, -1)
 	if len(indices) == 0 {
-		return textToHtmlEntity(text)
+		return textToHTMLEntity(text)
 	}
 	ent := &ContainerEntity{
 		BaseEntity: &BaseEntity{Tag: "span"},
@@ -429,7 +429,7 @@ func TextToEntity(text string, eventID id.EventID, linkify bool) Entity {
 	for i, item := range indices {
 		start, end := item[0], item[1]
 		if start > lastEnd {
-			ent.Children = append(ent.Children, textToHtmlEntity(text[lastEnd:start]))
+			ent.Children = append(ent.Children, textToHTMLEntity(text[lastEnd:start]))
 		}
 		link := text[start:end]
 		linkID := fmt.Sprintf("%s-%d", eventID, i)
@@ -437,7 +437,7 @@ func TextToEntity(text string, eventID id.EventID, linkify bool) Entity {
 		lastEnd = end
 	}
 	if lastEnd < len(text) {
-		ent.Children = append(ent.Children, textToHtmlEntity(text[lastEnd:]))
+		ent.Children = append(ent.Children, textToHTMLEntity(text[lastEnd:]))
 	}
 	return ent
 }


### PR DESCRIPTION
New lines were not displayed in plain text messages. There might be a better way, but I choose to manually convert the newline characters into BreakEntities inside of a ContainerEntity.

I didn't use my new function for the value of a plan text link, as it must not contain any new lines.

### Demo

#### Event
```json
{
  "room_id": "!***:matrix.org",
  "type": "m.room.message",
  "content": {
    "org.matrix.msc1767.text": "Probablement que j'ai pas répondu alors 😅\nMerci pour le partage mais je suis pas chaud pour y aller",
    "body": "Probablement que j'ai pas répondu alors 😅\nMerci pour le partage mais je suis pas chaud pour y aller",
    "msgtype": "m.text"
  }
}
```

#### Before
![2022-10-10-201655_849x77_scrot](https://user-images.githubusercontent.com/23519418/194930037-22bb651a-ed79-4e24-8d3f-1ce61c84d747.png)

#### After
![2022-10-10-201934_807x92_scrot](https://user-images.githubusercontent.com/23519418/194929972-70865fc3-51a5-4646-9337-06eb8dccc58e.png)
