### PR TITLE
Initial support for reaction redaction

### DIFF
--- a/interface/ui.go
+++ b/interface/ui.go
@@ -74,6 +74,7 @@ type RoomView interface {
 	AddRedaction(evt *muksevt.Event)
 	AddEdit(evt *muksevt.Event)
 	AddReaction(evt *muksevt.Event, key string)
+	RemoveReaction(evt *muksevt.Event, key string)
 	GetEvent(eventID id.EventID) Message
 	AddServiceMessage(message string)
 }

--- a/ui/messages/base.go
+++ b/ui/messages/base.go
@@ -150,6 +150,20 @@ func (msg *UIMessage) AddReaction(key string) {
 	sort.Sort(msg.Reactions)
 }
 
+func (msg *UIMessage) RemoveReaction(key string) {
+	for i, rs := range msg.Reactions {
+		if rs.Key == key {
+			if rs.Count == 1 {
+				msg.Reactions = append(msg.Reactions[:i], msg.Reactions[i+1:]...)
+			} else {
+				rs.Count--
+				msg.Reactions[i] = rs
+			}
+			break
+		}
+	}
+}
+
 func unixToTime(unix int64) time.Time {
 	timestamp := time.Now()
 	if unix != 0 {

--- a/ui/messages/parser.go
+++ b/ui/messages/parser.go
@@ -74,8 +74,7 @@ func directParseEvent(matrix ifc.MatrixContainer, room *rooms.Room, evt *muksevt
 		displayname = member.Displayname
 	}
 	if evt.Unsigned.RedactedBecause != nil || evt.Type == event.EventRedaction {
-		relates := evt.Content.AsReaction().OptionalGetRelatesTo()
-		if relates != nil && relates.Type == event.RelAnnotation {
+		if evt.Type == event.EventReaction {
 			// Redacted reactions are not displayed in the timeline as redacted messages
 			return nil
 		}

--- a/ui/room-view.go
+++ b/ui/room-view.go
@@ -928,6 +928,21 @@ func (view *RoomView) AddReaction(evt *muksevt.Event, key string) {
 	}
 }
 
+func (view *RoomView) RemoveReaction(evt *muksevt.Event, key string) {
+	msgView := view.MessageView()
+	msg := msgView.getMessageByID(evt.ID)
+	if msg == nil {
+		// Message not in view, nothing to do
+		return
+	}
+	heightChanged := len(msg.Reactions) == 1
+	msg.RemoveReaction(key)
+	if heightChanged {
+		// Replace buffer to update height of message
+		msgView.replaceBuffer(msg, msg)
+	}
+}
+
 func (view *RoomView) GetEvent(eventID id.EventID) ifc.Message {
 	message, ok := view.content.messageIDs[eventID]
 	if !ok {


### PR DESCRIPTION
With this patch, EventAnnotation events are now stored in gomuks' local history. ~~Thus, the Reaction map in the history is not used anymore.~~

Redacted reaction events are treated the same way as any other redacted event in the history, but are ignored by the Message's event parser, in order not to display them in the timeline.

There is still a problem with reactions that come from the initial sync, as it seems events are received in an aggregated form. Also all reactions received from the initial sync are doubled, but this bug existed prior to this change.

This might not be the best approach so I am completely open for suggestions.
Maybe instead of marking the event as redacted, it could be completely removed from the history. But I am not sure gomuks' history allows removing events.
Also some of the code could be refactored.


This with #391 together fixes the reaction counter of the messages.
