### PR TITLE
Better colors for some elements with black on white terminal themes

### DIFF
--- a/ui/room-list.go
+++ b/ui/room-list.go
@@ -98,7 +98,7 @@ func NewRoomList(parent *MainView) *RoomList {
 		scrollOffset: 0,
 
 		mainTextColor:           tcell.ColorDefault,
-		selectedTextColor:       tcell.ColorDefault,
+		selectedTextColor:       tcell.ColorWhite,
 		selectedBackgroundColor: tcell.ColorDarkGreen,
 	}
 	for _, tag := range list.tags {

--- a/ui/room-view.go
+++ b/ui/room-view.go
@@ -132,7 +132,7 @@ func NewRoomView(parent *MainView, room *rooms.Room) *RoomView {
 	}
 
 	view.topic.
-		SetTextColor(tcell.ColorDefault).
+		SetTextColor(tcell.ColorWhite).
 		SetBackgroundColor(tcell.ColorDarkGreen)
 
 	view.status.SetBackgroundColor(tcell.ColorDimGray)

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -48,6 +48,8 @@ type GomuksUI struct {
 
 func init() {
 	mauview.Styles.PrimitiveBackgroundColor = tcell.ColorDefault
+	mauview.Styles.PrimaryTextColor = tcell.ColorDefault
+	mauview.Styles.BorderColor = tcell.ColorDefault
 	mauview.Styles.ContrastBackgroundColor = tcell.ColorDarkGreen
 	if tcellDB := os.Getenv("TCELLDB"); len(tcellDB) == 0 {
 		if info, err := os.Stat("/usr/share/tcell/database"); err == nil && info.IsDir() {

--- a/ui/view-login.go
+++ b/ui/view-login.go
@@ -77,12 +77,20 @@ func (ui *GomuksUI) NewLoginView() mauview.Component {
 	}
 
 	hs := ui.gmx.Config().HS
-	view.homeserver.SetPlaceholder("https://example.com").SetText(hs)
-	view.username.SetPlaceholder("@user:example.com").SetText(string(ui.gmx.Config().UserID))
-	view.password.SetPlaceholder("correct horse battery staple").SetMaskCharacter('*')
+	view.homeserver.SetPlaceholder("https://example.com").SetText(hs).SetTextColor(tcell.ColorWhite)
+	view.username.SetPlaceholder("@user:example.com").SetText(string(ui.gmx.Config().UserID)).SetTextColor(tcell.ColorWhite)
+	view.password.SetPlaceholder("correct horse battery staple").SetMaskCharacter('*').SetTextColor(tcell.ColorWhite)
 
-	view.quitButton.SetOnClick(func() { ui.gmx.Stop(true) }).SetBackgroundColor(tcell.ColorDarkCyan)
-	view.loginButton.SetOnClick(view.Login).SetBackgroundColor(tcell.ColorDarkCyan)
+	view.quitButton.
+		SetOnClick(func() { ui.gmx.Stop(true) }).
+		SetBackgroundColor(tcell.ColorDarkCyan).
+		SetForegroundColor(tcell.ColorWhite).
+		SetFocusedForegroundColor(tcell.ColorWhite)
+	view.loginButton.
+		SetOnClick(view.Login).
+		SetBackgroundColor(tcell.ColorDarkCyan).
+		SetForegroundColor(tcell.ColorWhite).
+		SetFocusedForegroundColor(tcell.ColorWhite)
 
 	view.
 		SetColumns([]int{1, 10, 1, 30, 1}).


### PR DESCRIPTION
Added `ColorDefault` to more places by default and override some other specific places with white for better contrast.

This should not affect white on black terminal themes.

**Before**
![2022-11-15-150235_786x482_scrot](https://user-images.githubusercontent.com/23519418/202002763-fad9e8ee-64f3-440b-9a29-1deeb9bf074a.png)

**After**
![2022-11-15-200808_786x482_scrot](https://user-images.githubusercontent.com/23519418/202006402-5acbda2d-2b97-43ac-a682-9d526344c651.png)

**Before**
![2022-11-15-195113_793x482_scrot](https://user-images.githubusercontent.com/23519418/202002771-b4fe13a1-51a0-427d-835d-88575ea2e4e6.png)

**After**
![2022-11-15-194919_793x482_scrot](https://user-images.githubusercontent.com/23519418/202002770-b98c32a8-572d-40c6-846c-beeb0d30dcd6.png)

