### PR TITLE
fixed: room tags event listening

### DIFF
--- a/matrix/sync.go
+++ b/matrix/sync.go
@@ -258,7 +258,12 @@ func (s *GomuksSyncer) GetFilterJSON(_ id.UserID) *mautrix.Filter {
 			},
 		},
 		AccountData: mautrix.FilterPart{
-			Types: []event.Type{event.AccountDataPushRules, event.AccountDataDirectChats, AccountDataGomuksPreferences},
+			Types: []event.Type{
+				event.AccountDataPushRules,
+				event.AccountDataDirectChats,
+				AccountDataGomuksPreferences,
+				event.AccountDataRoomTags,
+			},
 		},
 		Presence: mautrix.FilterPart{
 			NotTypes: []event.Type{event.NewEventType("*")},


### PR DESCRIPTION
It's been a little while that room tag were not working for me. I was able to add some (visible in other clients like nheko) but gomuks never got them back.

After hacking around it seemed that the generated JSON filter (which from what I understand is a way to only ask to be notified for particular events) was not correct. This simple patch fixes all the room tags issues I had.

I'm not sure if this is an elegant fix though. Please let me know