### PR TITLE
First draft get `ranger`-in-thread as `/upload` file picker B)

### DIFF
--- a/lib/filepicker/filepicker.go
+++ b/lib/filepicker/filepicker.go
@@ -53,6 +53,8 @@ func Open(confDir string) (string, error) {
 
 	cmd := exec.Command(
 		file_browser,
+		// TODO: also offer config option to allow custom bootup-path?
+		os.Getenv("HOME"),
 		flag,
 	)
 	// args := []string{file_browser, flag}


### PR DESCRIPTION
As per wayy too much noise while I rubber ducked through this in the chat room 😂 

Obviously much thanks to @tulir for help with the goroutine syncing stuff in terms of supporting suspending `gomuks`' UI while `ranger` runs 🏄🏼 

---
#### Much more ToDo:
- [ ] fix the panic when `.config/gomuks/_last_upload_file.txt` does not exist 😂 
  - [ ] should we rename this to `upload_file_history.toml` or something?
  - maybe this would be handy so that users can check the record of all their uploads?
  
- [ ] put up a video of this new integration for everyone to see 😎 

- [ ] add back original support for `zenity` file browser?
  - imo using `ranger` like this is wayy more *in the spirit of* `gomuks`, so maybe you'll want to just drop it?
  
- [ ] add optional `i3-msg exec $TERMINAL -e ranger` support so that you get the same behavior as `zenity` where a whole new terminal (emulator) is spawned and then closes on `ranger` exit.

- [ ] it'd be **suuuper slick** if we could use ranger for opening media files as well - eg. when clicking an inline image?