### PR TITLE
new: add line breaks between senders

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -60,6 +60,7 @@ type UserPreferences struct {
 	DisableNotifications bool `yaml:"disable_notifications"`
 	DisableShowURLs      bool `yaml:"disable_show_urls"`
 	AltEnterToSend       bool `yaml:"alt_enter_to_send"`
+	EnableLineBreaks     bool `yaml:"enable_line_breaks"`
 
 	InlineURLMode string `yaml:"inline_url_mode"`
 }

--- a/matrix/mediainfo.go
+++ b/matrix/mediainfo.go
@@ -38,6 +38,7 @@ func getImageInfo(path string) (event.FileInfo, error) {
 	if err != nil {
 		return info, fmt.Errorf("failed to open image to get info: %w", err)
 	}
+	defer file.Close()
 	cfg, _, err := image.DecodeConfig(file)
 	if err != nil {
 		return info, fmt.Errorf("failed to get image info: %w", err)

--- a/ui/commands.go
+++ b/ui/commands.go
@@ -984,6 +984,7 @@ var toggleMsg = map[string]ToggleMessage{
 	"showurls":      SimpleToggleMessage("show URLs in text format"),
 	"inlineurls":    InvertedToggleMessage("use fancy terminal features to render URLs inside text"),
 	"newline":       NewlineKeybindMessage("should <alt+enter> make a new line or send the message"),
+	"linebreaks":    SimpleToggleMessage("line breaks between senders"),
 }
 
 func makeUsage() string {
@@ -1042,6 +1043,17 @@ func cmdToggle(cmd *Command) {
 			continue
 		case "newline":
 			val = &cmd.Config.Preferences.AltEnterToSend
+		case "linebreaks":
+			switch cmd.Config.Preferences.EnableLineBreaks {
+			case true:
+				cmd.Config.Preferences.EnableLineBreaks = false
+				cmd.Reply("Disabled line breaks between senders. Restart gomuks to apply changes.")
+			default:
+				cmd.Config.Preferences.EnableLineBreaks = true
+				cmd.Reply("Enabled line breaks between senders. Restart gomuks to apply changes.")
+			}
+			continue
+
 		default:
 			cmd.Reply("Unknown toggle %s. Use /toggle without arguments for a list of togglable things.", thing)
 			return

--- a/ui/messages/base.go
+++ b/ui/messages/base.go
@@ -74,6 +74,7 @@ type UIMessage struct {
 	SenderID           id.UserID
 	SenderName         string
 	DefaultSenderColor tcell.Color
+	HideTimestamp      bool
 	Timestamp          time.Time
 	State              muksevt.OutgoingState
 	IsHighlight        bool
@@ -277,6 +278,9 @@ func (msg *UIMessage) Time() time.Time {
 
 // FormatTime returns the formatted time when the message was sent.
 func (msg *UIMessage) FormatTime() string {
+	if msg.HideTimestamp {
+		return ""
+	}
 	return msg.Timestamp.Format(TimeFormat)
 }
 
@@ -289,6 +293,10 @@ func (msg *UIMessage) SameDate(message *UIMessage) bool {
 	year1, month1, day1 := msg.Timestamp.Date()
 	year2, month2, day2 := message.Timestamp.Date()
 	return day1 == day2 && month1 == month2 && year1 == year2
+}
+
+func (msg *UIMessage) SameSender(message *UIMessage) bool {
+	return msg.SenderID.URI().PrimaryIdentifier() == message.SenderID.URI().PrimaryIdentifier()
 }
 
 func (msg *UIMessage) ID() id.EventID {

--- a/ui/messages/expandedtextmessage.go
+++ b/ui/messages/expandedtextmessage.go
@@ -69,6 +69,18 @@ func NewDateChangeMessage(text string) *UIMessage {
 	}
 }
 
+func NewSenderChangeMessage() *UIMessage {
+	return &UIMessage{
+		SenderID:      "",
+		SenderName:    "",
+		IsService:     true,
+		HideTimestamp: true,
+		Renderer: &ExpandedTextMessage{
+			Text: tstring.NewColorTString(" ", tcell.ColorGreen),
+		},
+	}
+}
+
 func (msg *ExpandedTextMessage) Clone() MessageRenderer {
 	return &ExpandedTextMessage{
 		Text: msg.Text.Clone(),


### PR DESCRIPTION
This patch adds an empty line between events coming from two different
senders. This behavior can be controlled by /toggle linebreaks. The
default it off, to keep the current behavior intact.