### PR TITLE
show notification immediately when unfocused

### DIFF
--- a/ui/view-main.go
+++ b/ui/view-main.go
@@ -418,7 +418,7 @@ func (view *MainView) NotifyMessage(room *rooms.Room, message ifc.Message, shoul
 		view.matrix.MarkRead(room.ID, message.ID())
 	}
 
-	if should.Notify && !recentlyFocused && !view.config.Preferences.DisableNotifications {
+	if should.Notify && (!isFocused || !recentlyFocused) && !view.config.Preferences.DisableNotifications {
 		// Push rules say notify and the terminal is not focused, send desktop notification.
 		shouldPlaySound := should.PlaySound &&
 			should.SoundName == "default" &&


### PR DESCRIPTION
This patch makes sure the notifications will show immediately if the application is not focused, instead of showing only if not recently focused.