### PR TITLE
Fix debug dir on linux and disable logging by default

### DIFF
--- a/debug/debug.go
+++ b/debug/debug.go
@@ -67,7 +67,7 @@ func getUname() string {
 func Initialize() {
 	err := os.MkdirAll(LogDirectory, 0750)
 	if err != nil {
-		RecoverPrettyPanic = false
+		RecoverPrettyPanic = true
 		DeadlockDetection = false
 		WriteLogs = false
 		return

--- a/debug/debug.go
+++ b/debug/debug.go
@@ -32,7 +32,7 @@ import (
 )
 
 var writer io.Writer
-var RecoverPrettyPanic bool
+var RecoverPrettyPanic bool = true
 var DeadlockDetection bool
 var WriteLogs bool
 var OnRecover func()
@@ -44,7 +44,7 @@ func GetUserDebugDir() string {
 	}
 	// See https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
 	if xdgStateHome := os.Getenv("XDG_STATE_HOME"); xdgStateHome != "" {
-		return xdgStateHome
+		return filepath.Join(xdgStateHome, "gomuks")
 	}
 	home := os.Getenv("HOME")
 	if home == "" {
@@ -67,7 +67,7 @@ func getUname() string {
 func Initialize() {
 	err := os.MkdirAll(LogDirectory, 0750)
 	if err != nil {
-		RecoverPrettyPanic = true
+		RecoverPrettyPanic = false
 		DeadlockDetection = false
 		WriteLogs = false
 		return

--- a/main.go
+++ b/main.go
@@ -63,13 +63,10 @@ func main() {
 		debug.LogDirectory = debugDir
 	}
 	debugLevel := strings.ToLower(os.Getenv("DEBUG"))
-	if debugLevel != "0" && debugLevel != "f" && debugLevel != "false" {
-		debug.WriteLogs = true
-		debug.RecoverPrettyPanic = true
-	}
 	if debugLevel == "1" || debugLevel == "t" || debugLevel == "true" {
 		debug.RecoverPrettyPanic = false
 		debug.DeadlockDetection = true
+		debug.WriteLogs = true
 	}
 	debug.Initialize()
 	defer debug.Recover()


### PR DESCRIPTION
Closes: #429

This PR does two things:
* Change log dir to ~/.local/state if `XDG_STATE_HOME` is unset which is as per the freedesktop guidelines
* Disables logging by default
   + Gomuks keeps logging events, and the size of the debug log can quickly shoot up if there are any crashes. Unless the user wants, it is not a good idea to keep dumping logs by default. However, logging would work just fine if `DEBUG=1` is passed.

Tested this on top of 0.3.0 gomuks release.