### PR TITLE
Keep whitespaces at the extremities of codeblocks

### DIFF
--- a/ui/messages/html/parser.go
+++ b/ui/messages/html/parser.go
@@ -345,11 +345,10 @@ func (parser *htmlParser) codeblockToEntity(node *html.Node) Entity {
 			}
 		}
 	}
-	parser.preserveWhitespace = true
-	text := (&ContainerEntity{
-		Children: parser.nodeToEntities(node.FirstChild),
-	}).PlainText()
-	parser.preserveWhitespace = false
+	text := "\n"
+	if node.FirstChild != nil {
+		text = node.FirstChild.Data
+	}
 	return parser.syntaxHighlight(text, lang)
 }
 


### PR DESCRIPTION
This is an old commit I forgot to send, as a follow-up to #387

> Now that codeblocks tokens are correctly parsed, there is no need anymore for parsing its content and then extracting its plaintext version. This allows to save some computation and to preserve the whitespaces at the beginning and end of a codeblock.
>
> Previously, messages containing only an empty codeblock where not displayed. Now the text of the codeblock defaults to '\n' so the message is always displayed.
