### PR TITLE
cmd/gomuks: move web package from pkg/gomuks

### DIFF
--- a/cmd/gomuks/main.go
+++ b/cmd/gomuks/main.go
@@ -30,6 +30,7 @@ import (
 
 	"go.mau.fi/gomuks/pkg/gomuks"
 	"go.mau.fi/gomuks/pkg/hicli"
+	"go.mau.fi/gomuks/web"
 )
 
 var (
@@ -77,6 +78,7 @@ func main() {
 	gmx.Commit = Commit
 	gmx.LinkifiedVersion = LinkifiedVersion
 	gmx.BuildTime = ParsedBuildTime
+	gmx.FrontendFS = web.Frontend
 	gmx.Run()
 }
 

--- a/pkg/gomuks/gomuks.go
+++ b/pkg/gomuks/gomuks.go
@@ -18,6 +18,7 @@ package gomuks
 
 import (
 	"context"
+	"embed"
 	"fmt"
 	"maps"
 	"net/http"
@@ -54,6 +55,8 @@ type Gomuks struct {
 	CacheDir  string
 	TempDir   string
 	LogDir    string
+
+	FrontendFS embed.FS
 
 	Config Config
 

--- a/pkg/gomuks/server.go
+++ b/pkg/gomuks/server.go
@@ -39,7 +39,6 @@ import (
 	"maunium.net/go/mautrix"
 
 	"go.mau.fi/gomuks/pkg/hicli"
-	"go.mau.fi/gomuks/web"
 )
 
 func (gmx *Gomuks) StartServer() {
@@ -62,7 +61,7 @@ func (gmx *Gomuks) StartServer() {
 		router.Handle("/debug/", http.DefaultServeMux)
 	}
 	router.Handle("/_gomuks/", apiHandler)
-	if frontend, err := fs.Sub(web.Frontend, "dist"); err != nil {
+	if frontend, err := fs.Sub(gmx.FrontendFS, "dist"); err != nil {
 		gmx.Log.Warn().Msg("Frontend not found")
 	} else {
 		router.Handle("/", gmx.FrontendCacheMiddleware(http.FileServerFS(frontend)))


### PR DESCRIPTION
makes using the library without the web bits easier