### PR TITLE
Implement MSC4193

### DIFF
--- a/web/src/api/types/mxtypes.ts
+++ b/web/src/api/types/mxtypes.ts
@@ -133,6 +133,8 @@ export interface MediaMessageEventContent extends BaseMessageEventContent {
 	url?: ContentURI
 	file?: EncryptedFile
 	info?: MediaInfo
+	"m.spoiler"?: boolean
+	"m.spoiler.reason"?: string
 }
 
 export interface ReactionEventContent {

--- a/web/src/ui/timeline/content/index.css
+++ b/web/src/ui/timeline/content/index.css
@@ -84,7 +84,7 @@ div.html-body {
 		max-width: 5rem;
 	}
 
-	span.hicli-spoiler {
+	.hicli-spoiler {
 		filter: blur(4px);
 		transition: filter .5s;
 		cursor: var(--clickable-cursor);
@@ -163,6 +163,20 @@ div.media-container {
 	&.video-container {
 		width: 100%;
 		height: 240px;
+	}
+	&.attachment-spoiler {
+		filter: blur(4px);
+		transition: filter .5s;
+		cursor: var(--clickable-cursor);
+
+		&.spoiler-revealed {
+			filter: none;
+			cursor: initial;
+		}
+
+		&:not(.spoiler-revealed) a {
+			pointer-events: none;
+		}
 	}
 
 	> a {

--- a/web/src/ui/timeline/content/useMediaContent.tsx
+++ b/web/src/ui/timeline/content/useMediaContent.tsx
@@ -28,9 +28,21 @@ export const useMediaContent = (
 		? getEncryptedMediaURL(content.info.thumbnail_file.url) : getMediaURL(content.info?.thumbnail_url)
 	if (content.msgtype === "m.image" || evtType === "m.sticker") {
 		const style = calculateMediaSize(content.info?.w, content.info?.h, containerSize)
-		let className = "image-container"
+		const classes = ["image-container"]
 		if(content["m.spoiler"] === true) {
-			className += " attachment-spoiler"
+			classes.push("attachment-spoiler")
+		}
+		const lightBox = use(LightboxContext)
+
+		const onClick = (event: React.MouseEvent<HTMLImageElement>) => {
+			// Check if it is spoilered. If it is, remove the attachment-spoiler class
+			if(event.currentTarget.parentElement?.classList.contains("attachment-spoiler")) {
+				console.debug("Removing spoiler")
+				event.currentTarget.parentElement?.classList.remove("attachment-spoiler")
+			} else {
+				console.debug("Opening lightbox")
+				return lightBox(event)
+			}
 		}
 
 		return [<img
@@ -39,8 +51,8 @@ export const useMediaContent = (
 			src={mediaURL}
 			alt={content.filename ?? content.body}
 			title={content["m.spoiler.reason"]}
-			onClick={use(LightboxContext)}
-		/>, className, style.container]
+			onClick={onClick}
+		/>, classes.join(" "), style.container]
 	} else if (content.msgtype === "m.video") {
 		const autoplay = false
 		const controls = !content.info?.["fi.mau.hide_controls"]

--- a/web/src/ui/timeline/content/useMediaContent.tsx
+++ b/web/src/ui/timeline/content/useMediaContent.tsx
@@ -37,10 +37,9 @@ export const useMediaContent = (
 		const onClick = (event: React.MouseEvent<HTMLImageElement>) => {
 			// Check if it is spoilered. If it is, remove the attachment-spoiler class
 			if(event.currentTarget.parentElement?.classList.contains("attachment-spoiler")) {
-				console.debug("Removing spoiler")
+				event.preventDefault()
 				event.currentTarget.parentElement?.classList.remove("attachment-spoiler")
 			} else {
-				console.debug("Opening lightbox")
 				return lightBox(event)
 			}
 		}
@@ -66,6 +65,19 @@ export const useMediaContent = (
 				event.currentTarget.currentTime = 0
 			}
 		}
+		let classes = ["video-container"]
+		if(content["m.spoiler"] === true) {
+			classes.push("attachment-spoiler")
+		}
+		const onPlay = (event: React.MouseEvent<HTMLVideoElement>) => {
+			// onclick doesn't appear to work for <video> elements, so we use onPlay instead
+			if(classes.includes("attachment-spoiler")) {
+				event.preventDefault()
+				event.currentTarget.pause()  // stop it autoplaying before the spoiler is removed
+				classes = classes.filter((c) => c !== "attachment-spoiler")
+				event.currentTarget.parentElement?.classList.remove("attachment-spoiler")
+			}
+		}
 		return [<video
 			autoPlay={autoplay}
 			controls={controls}
@@ -74,9 +86,11 @@ export const useMediaContent = (
 			onMouseOver={onMouseOver}
 			onMouseOut={onMouseOut}
 			preload="none"
+			title={content["m.spoiler.reason"]}
+			onPlay={onPlay}
 		>
 			<source src={mediaURL} type={content.info?.mimetype}/>
-		</video>, "video-container", {}]
+		</video>, classes.join(" "), {}]
 	} else if (content.msgtype === "m.audio") {
 		return [<audio controls src={mediaURL} preload="none"/>, "audio-container", {}]
 	} else if (content.msgtype === "m.file") {

--- a/web/src/ui/timeline/content/useMediaContent.tsx
+++ b/web/src/ui/timeline/content/useMediaContent.tsx
@@ -28,13 +28,19 @@ export const useMediaContent = (
 		? getEncryptedMediaURL(content.info.thumbnail_file.url) : getMediaURL(content.info?.thumbnail_url)
 	if (content.msgtype === "m.image" || evtType === "m.sticker") {
 		const style = calculateMediaSize(content.info?.w, content.info?.h, containerSize)
+		let className = "image-container"
+		if(content["m.spoiler"] === true) {
+			className += " attachment-spoiler"
+		}
+
 		return [<img
 			loading="lazy"
 			style={style.media}
 			src={mediaURL}
 			alt={content.filename ?? content.body}
+			title={content["m.spoiler.reason"]}
 			onClick={use(LightboxContext)}
-		/>, "image-container", style.container]
+		/>, className, style.container]
 	} else if (content.msgtype === "m.video") {
 		const autoplay = false
 		const controls = !content.info?.["fi.mau.hide_controls"]


### PR DESCRIPTION
This PR aims to implement [MSC4193](https://github.com/matrix-org/matrix-spec-proposals/pull/4193) (m.spoiler) for media in Matrix.

Currently, this PR supports rendering blurred images and videos, with the html `title` set to the `m.spoiler.reason`, and the spoiler is removed on click.
It does not currently support sending spoilered media.
It would also be nice to have the spoiler reason somewhere more prominent. Perhaps a custom HTML tooltip that appears instantly rather than relying on the html title?

Screenshots:

![video](https://github.com/user-attachments/assets/41d6ef64-bde1-4c95-b357-1f811fa4e61a)
![image](https://github.com/user-attachments/assets/3df408df-fec9-4e0f-b936-bf948fbbd9cb)
