### PR TITLE
web/css: set css color-scheme property to match theme

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,4 +1,5 @@
 :root {
+	color-scheme: light;
 	--font-stack: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
 	--monospace-font-stack: "Fira Code", monospace;
 
@@ -67,6 +68,7 @@
 	--clickable-cursor: default;
 
 	@media (prefers-color-scheme: dark) {
+		color-scheme: dark;
 		--background-color: #000;
 		--login-background-color: #111;
 		--text-color: #fff;


### PR DESCRIPTION
This is a minor fix, mainly for the scrollbar on chrome+windows+dark mode.

Before:
![image](https://github.com/user-attachments/assets/71520858-84e9-412c-ba55-c08a6495f11c)
After
![image](https://github.com/user-attachments/assets/f55611ee-aeb2-4029-b58b-e0465499b6fb)
