### PR TITLE
web/timeline: use blurhash before image loaded and for spoilers

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.pre-commit-eslint.sh
+++ b/.pre-commit-eslint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd web > /dev/null
 if [[ -f "./node_modules/.bin/eslint" ]]; then
 	ARGS=("$@")

--- a/.pre-commit-tsc.sh
+++ b/.pre-commit-tsc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd web > /dev/null
 if [[ -f "./node_modules/.bin/tsc" ]]; then
 	tsc --build --noEmit

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1732521221,
+        "narHash": "sha256-2ThgXBUXAE1oFsVATK1ZX9IjPcS4nKFOAjhPNKuiMn0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,40 @@
+{
+  description = "Gomuks development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    (flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          config.permittedInsecurePackages = [ "olm-3.2.16" ];
+        };
+      in {
+        devShells = {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              glib-networking
+              go-task
+              go-tools
+              gotools
+              gst_all_1.gstreamer
+              gst_all_1.gst-plugins-base
+              gst_all_1.gst-plugins-good
+              gst_all_1.gst-plugins-bad
+              gst_all_1.gst-plugins-ugly
+              gst_all_1.gst-libav
+              gst_all_1.gst-vaapi
+              libsoup
+              olm
+              pkg-config
+              pre-commit
+              webkitgtk_4_1
+            ];
+          };
+        };
+      }));
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,8 +12,10 @@
 				"@types/react": "npm:types-react@rc",
 				"@types/react-dom": "npm:types-react-dom@rc",
 				"@wailsio/runtime": "^3.0.0-alpha.29",
+				"blurhash": "^2.0.5",
 				"katex": "^0.16.11",
 				"react": "^19.0.0-rc.1",
+				"react-blurhash": "^0.3.0",
 				"react-dom": "^19.0.0-rc.1",
 				"react-spinners": "^0.14.1",
 				"unhomoglyph": "^1.0.6"
@@ -2269,6 +2271,12 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/blurhash": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/blurhash/-/blurhash-2.0.5.tgz",
+			"integrity": "sha512-cRygWd7kGBQO3VEhPiTgq4Wc43ctsM+o46urrmPOiuAe+07fzlSB9OJVdpgDL0jPqXUVQ9ht7aq7kxOeJHRK+w==",
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
@@ -4639,6 +4647,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/react-blurhash": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/react-blurhash/-/react-blurhash-0.3.0.tgz",
+			"integrity": "sha512-XlKr4Ns1iYFRnk6DkAblNbAwN/bTJvxTVoxMvmTcURdc5oLoXZwqAF9N3LZUh/HT+QFlq5n6IS6VsDGsviYAiQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"blurhash": "^2.0.3",
+				"react": ">=15"
 			}
 		},
 		"node_modules/react-dom": {

--- a/web/package.json
+++ b/web/package.json
@@ -14,8 +14,10 @@
 		"@types/react": "npm:types-react@rc",
 		"@types/react-dom": "npm:types-react-dom@rc",
 		"@wailsio/runtime": "^3.0.0-alpha.29",
+		"blurhash": "^2.0.5",
 		"katex": "^0.16.11",
 		"react": "^19.0.0-rc.1",
+		"react-blurhash": "^0.3.0",
 		"react-dom": "^19.0.0-rc.1",
 		"react-spinners": "^0.14.1",
 		"unhomoglyph": "^1.0.6"

--- a/web/src/api/types/mxtypes.ts
+++ b/web/src/api/types/mxtypes.ts
@@ -126,6 +126,11 @@ export interface RelatesTo {
 	}
 }
 
+export interface ContentWarning {
+	type: string
+	description?: string
+}
+
 export interface BaseMessageEventContent {
 	msgtype: string
 	body: string
@@ -133,6 +138,8 @@ export interface BaseMessageEventContent {
 	format?: "org.matrix.custom.html"
 	"m.mentions"?: Mentions
 	"m.relates_to"?: RelatesTo
+	"m.content_warning"?: ContentWarning
+	"town.robin.msc3725.content_warning"?: ContentWarning
 }
 
 export interface TextMessageEventContent extends BaseMessageEventContent {
@@ -178,6 +185,7 @@ export interface MediaInfo {
 
 	"fi.mau.hide_controls"?: boolean
 	"fi.mau.loop"?: boolean
+	"xyz.amorgan.blurhash"?: string
 }
 
 export interface LocationMessageEventContent extends BaseMessageEventContent {

--- a/web/src/ui/timeline/content/index.css
+++ b/web/src/ui/timeline/content/index.css
@@ -199,6 +199,21 @@ div.html-body {
 }
 
 div.media-container {
+	&.image-container {
+		.placeholder {
+			position: relative;
+
+			.spoiler-indicator {
+				position: absolute;
+				top: 50%;
+				left: 50%;
+				transform: translate(-50%, -50%);
+				background-color: rgba(0,0,0,0.3);
+				padding: 0.5rem;
+			}
+		}
+	}
+
 	&.video-container {
 		width: 100%;
 		height: 240px;


### PR DESCRIPTION
This PR implements support for rendering [MSC2448](https://github.com/matrix-org/matrix-spec-proposals/pull/2448) blurhashes and adds partial support for [MSC3725](https://github.com/matrix-org/matrix-spec-proposals/pull/3725/files) (content warnings, spoilers).

During image load, the blurhash (if present) is shown instead of the image until the image has been loaded.

Additionally, if it is a spoiler, then it will show up like this (using the blurhash):

![2024-11-30-18:35:26](https://github.com/user-attachments/assets/f6ab8073-bf0d-45fd-89b6-368e7ed22c89)

then, on click

![2024-11-30-18:35:31](https://github.com/user-attachments/assets/4e0c986e-7377-4c33-8d0e-9d797bdb6245)

-------

I couldn't figure out how to include blurhash exactly correctly. There were some dependency things that couldn't be resolved. React something something