### PR TITLE
web/roomlist: prevent overflow in unread counters

### DIFF
--- a/web/src/ui/roomlist/RoomList.css
+++ b/web/src/ui/roomlist/RoomList.css
@@ -106,22 +106,28 @@ div.room-entry {
 		width: 3rem;
 
 		> div.unread-count {
+			--unread-count-size: 1rem;
+			--unread-count-padding-inline: calc(1rem/4);
+			--unread-count-padding-block: calc(1rem/8);
+
 			display: flex;
 			align-items: center;
 			justify-content: center;
-			border-radius: 50%;
+            border-radius: var(--unread-count-size);
 			color: var(--unread-counter-text-color);
 
 			background-color: var(--unread-counter-message-bg);
-			width: 1rem;
-			height: 1rem;
+			height: var(--unread-count-size);
+            min-width: calc(var(--unread-count-size) - 2*(var(--unread-count-padding-inline) - var(--unread-count-padding-block)));
+
 			line-height: 1;
 			font-size: .75em;
 
+            padding-inline: var(--unread-count-padding-inline);
+			padding-block: var(--unread-count-padding-block);
+
 			&.notified, &.marked-unread, &.highlighted {
-				width: 1.5rem;
-				height: 1.5rem;
-				padding-bottom: 0;
+				--unread-count-size: 1.5rem;
 				font-size: 1em;
 				font-weight: bold;
 			}

--- a/web/src/ui/roomlist/RoomList.css
+++ b/web/src/ui/roomlist/RoomList.css
@@ -107,8 +107,8 @@ div.room-entry {
 
 		> div.unread-count {
 			--unread-count-size: 1rem;
-			--unread-count-padding-inline: calc(1rem/4);
-			--unread-count-padding-block: calc(1rem/8);
+			--unread-count-padding-inline: calc(var(--unread-count-size)/4);
+			--unread-count-padding-block: calc(var(--unread-count-size)/8);
 
 			display: flex;
 			align-items: center;


### PR DESCRIPTION
Fixes #540

![image](https://github.com/user-attachments/assets/2561d46a-a964-4088-b971-45f5f71fceb4)

Padding in both inline and block directions is configurable with the respective `unread-count-padding` CSS variables - if you'd prefer, I can move these to `index.css` / `:root` for easier overrides.