### PR TITLE
web/timeline: add hover text to member events

### DIFF
--- a/web/src/ui/timeline/content/MemberBody.tsx
+++ b/web/src/ui/timeline/content/MemberBody.tsx
@@ -61,9 +61,9 @@ function useChangeDescription(
 				return <>set their displayname to <span className="name">{content.displayname}</span></>
 			}
 			return <>
-				changed their displayname from <span className="name">
+				changed their displayname from <span className="name" title={prevContent.displayname}>
 					{prevContent.displayname}
-				</span> to <span className="name">{content.displayname}</span>
+				</span> to <span className="name" title={content.displayname}>{content.displayname}</span>
 			</>
 		} else if (content.avatar_url !== prevContent.avatar_url) {
 			if (!content.avatar_url) {
@@ -120,7 +120,7 @@ const MemberBody = ({ event, sender }: EventContentProps) => {
 	const content = event.content as MemberEventContent
 	const prevContent = event.unsigned.prev_content as MemberEventContent | undefined
 	return <div className="member-body">
-		<span className="name sender-name">
+		<span className="name sender-name" title={sender?.content.displayname ?? event.sender}>
 			{sender?.content.displayname ?? event.sender}
 		</span> <span className="change-description">
 			{useChangeDescription(event.sender, event.state_key as UserID, content, prevContent)}


### PR DESCRIPTION
When hovering over a name in a membership event, it now has hovertext with the full displayname

Signed-off-by: Sumner Evans <me@sumnerevans.com>
