### PR TITLE
web/timeline: don't show replied-to message if message is redacted

### DIFF
--- a/web/src/ui/timeline/TimelineEvent.tsx
+++ b/web/src/ui/timeline/TimelineEvent.tsx
@@ -163,7 +163,7 @@ const TimelineEvent = ({ evt, prevEvt, disableMenu }: TimelineEventProps) => {
 			<span className="event-time" title={editTime ? `${fullTime} - ${editTime}` : fullTime}>{shortTime}</span>
 		</div>}
 		<div className="event-content">
-			{isEventID(replyTo) && BodyType !== HiddenEvent ? <ReplyIDBody
+			{isEventID(replyTo) && BodyType !== HiddenEvent && !evt.redacted_by ? <ReplyIDBody
 				room={roomCtx.store}
 				eventID={replyTo}
 				isThread={relatesTo?.rel_type === "m.thread"}


### PR DESCRIPTION
I'm not sure if it's intentional, but right now if you delete a message that was a reply to another message, the reply is still rendered:

![image](https://github.com/user-attachments/assets/ae6d22cd-9e60-4bfd-84f7-b55fe6d76546)

 I think it's weird, so this PR makes it so that it just looks like a deleted message with no info about the replied-to message:

![image](https://github.com/user-attachments/assets/641f12b3-40cd-4f3a-a5a9-c7fd354795b9)
