### PR TITLE
web/util: Change the tooltip background color to --background-color

### DIFF
--- a/web/src/ui/util/TooltipButton.css
+++ b/web/src/ui/util/TooltipButton.css
@@ -5,7 +5,7 @@ button.with-tooltip {
 		display: none;
 		position: absolute;
 		z-index: 5;
-		background-color: white;
+		background-color: var(--background-color);
 		border: 1px solid var(--border-color);
 		padding: .25rem;
 		border-radius: .25rem;


### PR DESCRIPTION
Currently it is harcoded to `#fff` which breaks dark mode:
![image](https://github.com/user-attachments/assets/dbf5622d-c61a-4d51-a421-9139cf874df4)

Changes:
![image](https://github.com/user-attachments/assets/b599775e-9173-47f5-8adc-c45ead41bcc3)
