### PR TITLE
web/roomview: show MXID and room ID on invite previews

### DIFF
--- a/web/src/ui/roomview/RoomPreview.tsx
+++ b/web/src/ui/roomview/RoomPreview.tsx
@@ -93,9 +93,10 @@ const RoomPreview = ({ roomID, via, alias, invite }: RoomPreviewProps) => {
 					src={getAvatarURL(invite.invited_by, invite.inviter_profile)}
 					alt=""
 				/>
-				{getDisplayname(invite.invited_by, invite.inviter_profile)} invited you to
+				{getDisplayname(invite.invited_by, invite.inviter_profile)} ({invite.invited_by}) invited you to
 			</div> : null}
 			<h2 className="room-name">{name}</h2>
+			<code>{invite?.room_id}</code>
 			<img
 				src={getRoomAvatarURL(invite ?? summary ?? { room_id: roomID })}
 				className="large avatar"


### PR DESCRIPTION
This lets gomuks show the MXID of the inviter and the room ID they're inviting you to. I hate spam!

![image](https://github.com/user-attachments/assets/3ba017c6-3f49-4be9-95dd-e19702da1be3)
