### PR TITLE
[wip] web/timeline: use tanstack virtual to virtualise timeline

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.1.0",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
+				"@tanstack/react-virtual": "^3.11.2",
 				"@wailsio/runtime": "^3.0.0-alpha.29",
 				"blurhash": "^2.0.5",
 				"katex": "^0.16.11",
@@ -1752,6 +1753,33 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@swc/counter": "^0.1.3"
+			}
+		},
+		"node_modules/@tanstack/react-virtual": {
+			"version": "3.11.2",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.11.2.tgz",
+			"integrity": "sha512-OuFzMXPF4+xZgx8UzJha0AieuMihhhaWG0tCqpp6tDzlFwOmNBPYMuLOtMJ1Tr4pXLHmgjcWhG6RlknY2oNTdQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@tanstack/virtual-core": "3.11.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@tanstack/virtual-core": {
+			"version": "3.11.2",
+			"resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.11.2.tgz",
+			"integrity": "sha512-vTtpNt7mKCiZ1pwU9hfKPhpdVO2sVzFQsxoVBGtOSHxlrRRzYr8iQ2TlwbAcRYCcEiZ9ECAM8kBzH0v2+VzfKw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
 			}
 		},
 		"node_modules/@types/estree": {

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
 		"preview": "vite preview"
 	},
 	"dependencies": {
+		"@tanstack/react-virtual": "^3.11.2",
 		"@wailsio/runtime": "^3.0.0-alpha.29",
 		"blurhash": "^2.0.5",
 		"katex": "^0.16.11",

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -305,7 +305,7 @@ export default class Client {
 		}
 	}
 
-	async loadMoreHistory(roomID: RoomID): Promise<void> {
+	async loadMoreHistory(roomID: RoomID): Promise<number> {
 		const room = this.store.rooms.get(roomID)
 		if (!room) {
 			throw new Error("Room not found")
@@ -324,6 +324,7 @@ export default class Client {
 			}
 			room.hasMoreHistory = resp.has_more
 			room.applyPagination(resp.events, resp.related_events, resp.receipts)
+			return resp.events.length
 		} finally {
 			room.paginating = false
 		}

--- a/web/src/ui/timeline/TimelineEvent.tsx
+++ b/web/src/ui/timeline/TimelineEvent.tsx
@@ -77,7 +77,9 @@ const EventSendStatus = ({ evt }: { evt: MemDBEvent }) => {
 	}
 }
 
-const TimelineEvent = ({ evt, prevEvt, disableMenu, smallReplies, isFocused, virtualIndex, ref }: TimelineEventProps) => {
+const TimelineEvent = ({
+	evt, prevEvt, disableMenu, smallReplies, isFocused, virtualIndex, ref,
+}: TimelineEventProps) => {
 	const roomCtx = useRoomContext()
 	const client = use(ClientContext)!
 	const mainScreen = use(MainScreenContext)

--- a/web/src/ui/timeline/TimelineEvent.tsx
+++ b/web/src/ui/timeline/TimelineEvent.tsx
@@ -39,7 +39,9 @@ export interface TimelineEventProps {
 	prevEvt: MemDBEvent | null
 	disableMenu?: boolean
 	smallReplies?: boolean
-	isFocused?: boolean
+	isFocused?: boolean,
+	virtualIndex?: number,
+	ref?: React.Ref<HTMLDivElement>
 }
 
 const fullTimeFormatter = new Intl.DateTimeFormat("en-GB", { dateStyle: "full", timeStyle: "medium" })
@@ -75,7 +77,7 @@ const EventSendStatus = ({ evt }: { evt: MemDBEvent }) => {
 	}
 }
 
-const TimelineEvent = ({ evt, prevEvt, disableMenu, smallReplies, isFocused }: TimelineEventProps) => {
+const TimelineEvent = ({ evt, prevEvt, disableMenu, smallReplies, isFocused, virtualIndex, ref }: TimelineEventProps) => {
 	const roomCtx = useRoomContext()
 	const client = use(ClientContext)!
 	const mainScreen = use(MainScreenContext)
@@ -145,9 +147,10 @@ const TimelineEvent = ({ evt, prevEvt, disableMenu, smallReplies, isFocused }: T
 		eventTS.getDate() !== prevEvtDate.getDate() ||
 		eventTS.getMonth() !== prevEvtDate.getMonth() ||
 		eventTS.getFullYear() !== prevEvtDate.getFullYear())) {
-		dateSeparator = <div className="date-separator">
+		const dateLabel = dateFormatter.format(eventTS)
+		dateSeparator = <div className="date-separator" role="separator" aria-label={dateLabel}>
 			<hr role="none"/>
-			{dateFormatter.format(eventTS)}
+			{dateLabel}
 			<hr role="none"/>
 		</div>
 	}
@@ -196,6 +199,8 @@ const TimelineEvent = ({ evt, prevEvt, disableMenu, smallReplies, isFocused }: T
 		className={wrapperClassNames.join(" ")}
 		onContextMenu={onContextMenu}
 		onClick={!disableMenu && isMobileDevice ? onClick : undefined}
+		data-index={virtualIndex}
+		ref={ref}
 	>
 		{!disableMenu && !isMobileDevice && <div
 			className={`context-menu-container ${forceContextMenuOpen ? "force-open" : ""}`}
@@ -248,10 +253,7 @@ const TimelineEvent = ({ evt, prevEvt, disableMenu, smallReplies, isFocused }: T
 			<ReadReceipts room={roomCtx.store} eventID={evt.event_id} />}
 		{evt.sender === client.userID && evt.transaction_id ? <EventSendStatus evt={evt}/> : null}
 	</div>
-	return <>
-		{dateSeparator}
-		{mainEvent}
-	</>
+	return mainEvent
 }
 
 export default React.memo(TimelineEvent)

--- a/web/src/ui/timeline/TimelineView.css
+++ b/web/src/ui/timeline/TimelineView.css
@@ -16,5 +16,15 @@ div.timeline-view {
 
 	> div.timeline-list {
 		padding-bottom: 2rem;
+
+		width: 100%;
+		position: relative;
+
+		> div.timeline-virtual-items {
+			position: absolute;
+			top: 0;
+			left: 0;
+			width: 100%
+		}
 	}
 }

--- a/web/src/ui/timeline/TimelineView.css
+++ b/web/src/ui/timeline/TimelineView.css
@@ -1,9 +1,6 @@
 div.timeline-view {
 	overflow-y: scroll;
-
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
+	contain: strict;
 
 	> div.timeline-beginning {
 		display: flex;

--- a/web/src/ui/timeline/TimelineView.tsx
+++ b/web/src/ui/timeline/TimelineView.tsx
@@ -146,12 +146,13 @@ const TimelineView = () => {
 		}
 	}, [focused, client, roomCtx, room, timeline])
 
+	const firstItem = items[0]
+
 	useEffect(() => {
 		if (!room.hasMoreHistory || room.paginating) {
 			return
 		}
 
-		const firstItem = virtualizer.getVirtualItems()[0]
 
 		// Load history if there is none
 		if (!firstItem) {
@@ -167,9 +168,8 @@ const TimelineView = () => {
 		}
 	}, [
 		room.hasMoreHistory, loadHistory,
-		virtualizer.getVirtualItems(),
 		room.paginating,
-		virtualizer,
+		firstItem,
 	])
 
 	return <div className="timeline-view" onScroll={handleScroll} ref={timelineViewRef}>


### PR DESCRIPTION
Seems to work pretty well so far

todo:
- re-add date separators
- further manual testing
- investigate [`shouldAdjustScrollPositionOnItemSizeChange`](https://tanstack.com/virtual/latest/docs/api/virtualizer#shouldadjustscrollpositiononitemsizechange) to fix some scroll jumps
- fix scroll jank as elements are measured in firefox

lower priority:
- allow jump-to-event (e.g. replies) to jump to events that have been unloaded by the virtualiser
- improve performance when adding loaded history to `timeline` (shifting indexes / pretending to array)