### PR TITLE
Add a display for m.policy.rule.{user,room,server}

### DIFF
--- a/web/src/api/types/mxtypes.ts
+++ b/web/src/api/types/mxtypes.ts
@@ -111,6 +111,12 @@ export interface ACLEventContent {
 	deny?: string[]
 }
 
+export interface PolicyRuleContent {
+	entity: string
+	reason: string
+	recommendation: string
+}
+
 export interface PowerLevelEventContent {
 	users?: Record<UserID, number>
 	users_default?: number

--- a/web/src/ui/MainScreen.tsx
+++ b/web/src/ui/MainScreen.tsx
@@ -217,6 +217,7 @@ class ContextFields implements MainScreenContextFields {
 	}
 
 	clickRightPanelOpener = (evt: React.MouseEvent) => {
+		evt.preventDefault()
 		const type = evt.currentTarget.getAttribute("data-target-panel")
 		if (type === "pinned-messages" || type === "members") {
 			this.setRightPanel({ type })

--- a/web/src/ui/timeline/content/PolicyRuleBody.tsx
+++ b/web/src/ui/timeline/content/PolicyRuleBody.tsx
@@ -50,8 +50,8 @@ const BanPolicyBody = ({ event, sender }: EventContentProps) => {
 		}
 	}
 	return <div className="policy-body">
-		{sender?.content.displayname ?? event.sender} {action} a policy rule {action === "removed" ? "un" : null}banning
-		{entity} for: {content.reason}
+		{sender?.content.displayname ?? event.sender} {action} a policy rule {action === "removed" ? "un" : null}&nbsp;
+		banning {entity} for: {content.reason}
 	</div>
 }
 

--- a/web/src/ui/timeline/content/PolicyRuleBody.tsx
+++ b/web/src/ui/timeline/content/PolicyRuleBody.tsx
@@ -1,0 +1,28 @@
+import { PolicyRuleContent } from "@/api/types"
+import EventContentProps from "./props.ts"
+
+const BanPolicyBody = ({ event, sender }: EventContentProps) => {
+	const content = event.content as PolicyRuleContent
+	const prevContent = event.unsigned.prev_content as PolicyRuleContent | undefined
+
+	if (prevContent !== undefined) {
+		// all fields for content are missing (this is against spec?) so we need to use the prev event's content
+		if (content.entity === undefined) {
+			// unban
+			return <div className="policy-body">
+				{sender?.content.displayname ?? event.sender} Removed the policy rule banning {prevContent.entity}
+			</div>
+		}
+		// update
+		return <div className="policy-body">
+			{sender?.content.displayname ?? event.sender} Updated a policy rule banning {content.entity} for
+			{content.reason}
+		</div>
+	}
+	// add
+	return <div className="policy-body">
+		{sender?.content.displayname ?? event.sender} Added a policy rule banning {content.entity} for {content.reason}
+	</div>
+}
+
+export default BanPolicyBody

--- a/web/src/ui/timeline/content/PolicyRuleBody.tsx
+++ b/web/src/ui/timeline/content/PolicyRuleBody.tsx
@@ -50,8 +50,8 @@ const BanPolicyBody = ({ event, sender }: EventContentProps) => {
 		}
 	}
 	return <div className="policy-body">
-		{sender?.content.displayname ?? event.sender} {action} a policy rule {action === "removed" ? "un" : null}&nbsp;
-		banning {entity} for: {content.reason}
+		{sender?.content.displayname ?? event.sender} {action} a policy
+		rule {action === "removed" ? "un" : null} banning {entity} for: {content.reason}
 	</div>
 }
 

--- a/web/src/ui/timeline/content/PolicyRuleBody.tsx
+++ b/web/src/ui/timeline/content/PolicyRuleBody.tsx
@@ -23,7 +23,7 @@ const BanPolicyBody = ({ event, sender }: EventContentProps) => {
 	const prevContent = event.unsigned.prev_content as PolicyRuleContent | undefined
 	const mainScreen = use(MainScreenContext)
 
-	let entity = <span>content.entity || prevContent?.entity</span>
+	let entity = <span>{content.entity || prevContent?.entity}</span>
 	if(event.type === "m.policy.rule.user" && !content.entity?.includes("*") && !content.entity?.includes("?")) {
 		// Is user policy, and does not include the glob chars * and ?
 		entity = (
@@ -50,8 +50,8 @@ const BanPolicyBody = ({ event, sender }: EventContentProps) => {
 		}
 	}
 	return <div className="policy-body">
-		{sender?.content.displayname ?? event.sender} {action} a policy rule
-		{action === "removed" ? "un" : null}banning {entity} for {content.reason}
+		{sender?.content.displayname ?? event.sender} {action} a policy rule {action === "removed" ? "un" : null}banning
+		{entity} for: {content.reason}
 	</div>
 }
 

--- a/web/src/ui/timeline/content/PolicyRuleBody.tsx
+++ b/web/src/ui/timeline/content/PolicyRuleBody.tsx
@@ -51,7 +51,7 @@ const BanPolicyBody = ({ event, sender }: EventContentProps) => {
 	}
 	return <div className="policy-body">
 		{sender?.content.displayname ?? event.sender} {action} a policy
-		rule {action === "removed" ? "un" : null} banning {entity} for: {content.reason}
+		rule {action === "removed" ? "un" : null}banning {entity} for: {content.reason}
 	</div>
 }
 

--- a/web/src/ui/timeline/content/PolicyRuleBody.tsx
+++ b/web/src/ui/timeline/content/PolicyRuleBody.tsx
@@ -1,27 +1,57 @@
+// gomuks - A Matrix client written in Go.
+// Copyright (C) 2024 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import { use } from "react"
 import { PolicyRuleContent } from "@/api/types"
+import MainScreenContext from "@/ui/MainScreenContext.ts"
 import EventContentProps from "./props.ts"
 
 const BanPolicyBody = ({ event, sender }: EventContentProps) => {
 	const content = event.content as PolicyRuleContent
 	const prevContent = event.unsigned.prev_content as PolicyRuleContent | undefined
+	const mainScreen = use(MainScreenContext)
 
-	if (prevContent !== undefined) {
-		// all fields for content are missing (this is against spec?) so we need to use the prev event's content
-		if (content.entity === undefined) {
-			// unban
-			return <div className="policy-body">
-				{sender?.content.displayname ?? event.sender} Removed the policy rule banning {prevContent.entity}
-			</div>
-		}
-		// update
-		return <div className="policy-body">
-			{sender?.content.displayname ?? event.sender} Updated a policy rule banning {content.entity} for
-			{content.reason}
-		</div>
+	let entity = <span>content.entity || prevContent?.entity</span>
+	if(event.type === "m.policy.rule.user" && !content.entity?.includes("*") && !content.entity?.includes("?")) {
+		// Is user policy, and does not include the glob chars * and ?
+		entity = (
+			<a
+				className="hicli-matrix-uri hicli-matrix-uri-user"
+				href={`matrix:u/${content.entity.slice(1)}`}
+				onClick={mainScreen.clickRightPanelOpener}
+				data-target-panel="user"
+				data-target-user={content.entity}
+			>
+				{content.entity}
+			</a>
+		)
 	}
-	// add
+
+	let action = "added"
+	if (prevContent) {
+		if (!content) {
+			// If the content is empty, the ban is revoked.
+			action = "removed"
+		} else {
+			// There is still content, so the policy was updated
+			action = "updated"
+		}
+	}
 	return <div className="policy-body">
-		{sender?.content.displayname ?? event.sender} Added a policy rule banning {content.entity} for {content.reason}
+		{sender?.content.displayname ?? event.sender} {action} a policy rule
+		{action === "removed" ? "un" : null}banning {entity} for {content.reason}
 	</div>
 }
 

--- a/web/src/ui/timeline/content/index.ts
+++ b/web/src/ui/timeline/content/index.ts
@@ -7,6 +7,7 @@ import LocationMessageBody from "./LocationMessageBody.tsx"
 import MediaMessageBody from "./MediaMessageBody.tsx"
 import MemberBody from "./MemberBody.tsx"
 import PinnedEventsBody from "./PinnedEventsBody.tsx"
+import PolicyRuleBody from "./PolicyRuleBody.tsx"
 import PowerLevelBody from "./PowerLevelBody.tsx"
 import RedactedBody from "./RedactedBody.tsx"
 import RoomAvatarBody from "./RoomAvatarBody.tsx"
@@ -24,6 +25,7 @@ export { default as MediaMessageBody } from "./MediaMessageBody.tsx"
 export { default as LocationMessageBody } from "./LocationMessageBody.tsx"
 export { default as MemberBody } from "./MemberBody.tsx"
 export { default as PinnedEventsBody } from "./PinnedEventsBody.tsx"
+export { default as PolicyRuleBody } from "./PolicyRuleBody.tsx"
 export { default as PowerLevelBody } from "./PowerLevelBody.tsx"
 export { default as RedactedBody } from "./RedactedBody.tsx"
 export { default as RoomAvatarBody } from "./RoomAvatarBody.tsx"
@@ -82,6 +84,12 @@ export function getBodyType(evt: MemDBEvent, forReply = false): React.FunctionCo
 		return RoomAvatarBody
 	case "m.room.server_acl":
 		return ACLBody
+	case "m.policy.rule.user":
+		return PolicyRuleBody
+	case "m.policy.rule.room":
+		return PolicyRuleBody
+	case "m.policy.rule.server":
+		return PolicyRuleBody
 	case "m.room.pinned_events":
 		return PinnedEventsBody
 	case "m.room.power_levels":
@@ -97,6 +105,7 @@ export function isSmallEvent(bodyType: React.FunctionComponent<EventContentProps
 	case RoomNameBody:
 	case RoomAvatarBody:
 	case ACLBody:
+	case PolicyRuleBody:
 	case PinnedEventsBody:
 	case PowerLevelBody:
 		return true


### PR DESCRIPTION
This PR simply adds a display for m.policy.rule.user, m.policy.rule.room, and m.policy.rule.server, similar to how m.room.server_acl is handled.

Demo:
![image](https://github.com/user-attachments/assets/02f3f96c-9222-4f1a-8b7d-ea8146b0ae7b)

This display only affects policy list rooms, such as https://matrix.to/#/#cme:nexy7574.co.uk.