### PR TITLE
web/composer: prevent sending when loading media

### DIFF
--- a/web/src/ui/composer/MessageComposer.tsx
+++ b/web/src/ui/composer/MessageComposer.tsx
@@ -166,7 +166,7 @@ const MessageComposer = () => {
 	const canSend = Boolean(state.text || state.media || state.location)
 	const onClickSend = (evt: React.FormEvent) => {
 		evt.preventDefault()
-		if (!canSend) {
+		if (!canSend || loadingMedia) {
 			return
 		}
 		doSendMessage(state)


### PR DESCRIPTION
We already are setting the button to disabled, but you can also invoke
onClickSend by pressing "Enter". See
https://github.com/tulir/gomuks/blob/b01b3f0e32d354c45df4159da05f3bb4ca029d61/web/src/ui/composer/MessageComposer.tsx#L615

Signed-off-by: Sumner Evans <me@sumnerevans.com>
