### PR TITLE
timeline: don't render empty url-previews div

### DIFF
--- a/web/src/ui/timeline/URLPreviews.css
+++ b/web/src/ui/timeline/URLPreviews.css
@@ -2,7 +2,7 @@ div.url-previews {
 	display: flex;
 	flex-direction: row;
 	gap: 1rem;
-	overflow-x: scroll;
+	overflow-x: auto;
 
 	> div.url-preview {
 		margin: 0.5rem 0;

--- a/web/src/ui/timeline/URLPreviews.tsx
+++ b/web/src/ui/timeline/URLPreviews.tsx
@@ -33,7 +33,7 @@ const URLPreviews = ({ event, room }: {
 	}
 
 	const previews = (event.content["com.beeper.linkpreviews"] ?? event.content["m.url_previews"]) as URLPreview[]
-	if (!previews) {
+	if (!previews || !previews.length) {
 		return null
 	}
 	return <div className="url-previews">


### PR DESCRIPTION
Before:

![2025-02-24-22:08:52](https://github.com/user-attachments/assets/5f518472-19ca-4b00-b4ed-e74f232fb76c)

After

![2025-02-24-22:09:09](https://github.com/user-attachments/assets/79c6ff6f-17d5-4cc0-9be6-cdb0fe2767f5)


Signed-off-by: Sumner Evans <me@sumnerevans.com>
