### PR TITLE
Avatar fallback support phone numbers

### DIFF
--- a/web/src/api/media.ts
+++ b/web/src/api/media.ts
@@ -74,8 +74,15 @@ function getFallbackCharacter(from: unknown, idx: number): string {
 	if (!from || typeof from !== "string" || from.length <= idx) {
 		return ""
 	}
+	
 	// Array.from appears to be the only way to handle Unicode correctly
-	return Array.from(from.slice(0, (idx + 1) * 2))[idx]?.toUpperCase().toWellFormed() ?? ""
+	const fallbackCharacter = Array.from(from.slice(0, (idx + 1) * 2))[idx]?.toUpperCase().toWellFormed() ?? "";
+	
+	// if it's a phone number, return "#"
+	// * - Any digit (`\d`) - phone numbers
+	// * - `(` - US Area Codes can start with parens
+	// * - `+` - international phone numbers
+	return fallbackCharacter.match(/[\d(+]/) ? "#" : fallbackCharacter
 }
 
 export const getAvatarURL = (

--- a/web/src/api/media.ts
+++ b/web/src/api/media.ts
@@ -80,7 +80,7 @@ function getFallbackCharacter(from: unknown, idx: number): string {
 	}
 	
 	// Array.from appears to be the only way to handle Unicode correctly
-	return Array.from(from.slice(0, (idx + 1) * 2))[idx]?.toUpperCase().toWellFormed() ?? "";
+	return Array.from(from.slice(0, (idx + 1) * 2))[idx]?.toUpperCase().toWellFormed() ?? ""
 }
 
 export const getAvatarURL = (

--- a/web/src/api/media.ts
+++ b/web/src/api/media.ts
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-import { parseMXC } from "@/util/validation.ts"
+import { isPhoneNumber, parseMXC } from "@/util/validation.ts"
 import { ContentURI, RoomID, UserID, UserProfile } from "./types"
 
 export const getMediaURL = (mxc?: string, encrypted: boolean = false): string | undefined => {
@@ -74,15 +74,13 @@ function getFallbackCharacter(from: unknown, idx: number): string {
 	if (!from || typeof from !== "string" || from.length <= idx) {
 		return ""
 	}
+
+	if (isPhoneNumber(from)) {
+		return "#"
+	}
 	
 	// Array.from appears to be the only way to handle Unicode correctly
-	const fallbackCharacter = Array.from(from.slice(0, (idx + 1) * 2))[idx]?.toUpperCase().toWellFormed() ?? "";
-	
-	// if it's a phone number, return "#"
-	// * - Any digit (`\d`) - phone numbers
-	// * - `(` - US Area Codes can start with parens
-	// * - `+` - international phone numbers
-	return fallbackCharacter.match(/[\d(+]/) ? "#" : fallbackCharacter
+	return Array.from(from.slice(0, (idx + 1) * 2))[idx]?.toUpperCase().toWellFormed() ?? "";
 }
 
 export const getAvatarURL = (

--- a/web/src/util/validation.ts
+++ b/web/src/util/validation.ts
@@ -17,6 +17,7 @@ import { ContentURI, EventID, RoomAlias, RoomID, UserID, UserProfile } from "@/a
 
 const simpleHomeserverRegex = /^[a-zA-Z0-9.:-]+$/
 const mediaRegex = /^mxc:\/\/([a-zA-Z0-9.:-]+)\/([a-zA-Z0-9_-]+)$/
+const phoneNumberRegex = /^(?:(?:\+\d{1,4}[-.\s]?)?(?:\(?\d{1,4}\)?[-.\s]?\d{1,4}[-.\s]?\d{1,4}|\d{5,10})|\d{4,6})$/;
 
 function isIdentifier<T>(identifier: unknown, sigil: string, requiresServer: boolean): identifier is T {
 	if (typeof identifier !== "string" || !identifier.startsWith(sigil)) {
@@ -38,6 +39,7 @@ export const isUserID = (userID: unknown) => isIdentifier<UserID>(userID, "@", t
 export const isRoomID = (roomID: unknown) => isIdentifier<RoomID>(roomID, "!", true)
 export const isRoomAlias = (roomAlias: unknown) => isIdentifier<RoomAlias>(roomAlias, "#", true)
 export const isMXC = (mxc: unknown): mxc is ContentURI => typeof mxc === "string" && mediaRegex.test(mxc)
+export const isPhoneNumber = (phone: unknown): boolean => typeof phone === "string" && phoneNumberRegex.test(phone)
 
 export interface ParsedMatrixURI {
 	identifier: UserID | RoomID | RoomAlias

--- a/web/src/util/validation.ts
+++ b/web/src/util/validation.ts
@@ -17,7 +17,7 @@ import { ContentURI, EventID, RoomAlias, RoomID, UserID, UserProfile } from "@/a
 
 const simpleHomeserverRegex = /^[a-zA-Z0-9.:-]+$/
 const mediaRegex = /^mxc:\/\/([a-zA-Z0-9.:-]+)\/([a-zA-Z0-9_-]+)$/
-const phoneNumberRegex = /^(?:(?:\+\d{1,4}[-.\s]?)?(?:\(?\d{1,4}\)?[-.\s]?\d{1,4}[-.\s]?\d{1,4}|\d{5,10})|\d{4,6})$/;
+const phoneNumberRegex = /^(?:(?:\+\d{1,4}[-.\s]?)?(?:\(?\d{1,4}\)?[-.\s]?\d{1,4}[-.\s]?\d{1,4}|\d{5,10})|\d{4,6})$/
 
 function isIdentifier<T>(identifier: unknown, sigil: string, requiresServer: boolean): identifier is T {
 	if (typeof identifier !== "string" || !identifier.startsWith(sigil)) {


### PR DESCRIPTION
I noticed that the avatars use a fallback character if an avatar isn't set but when this is a phone number it can lead to off centered characters or random digits:

![image](https://github.com/user-attachments/assets/a0721204-5768-462b-9b57-0006d6246e18)

Fixed this to replace likely phone numbers with `#`:

![image](https://github.com/user-attachments/assets/aecce14c-cc9a-4202-820f-d290eb5b3d07)


Didn't see a contribution guide so let me know if this isn't cool