### PR TITLE
web/statestore: don't hide video rooms

### DIFF
--- a/web/src/api/statestore/main.ts
+++ b/web/src/api/statestore/main.ts
@@ -183,6 +183,7 @@ export class StateStore {
 			return true
 		case "":
 		case "support.feline.policy.lists.msc.v1":
+		case "org.matrix.msc3417.call":
 		}
 		const replacementRoom = entry.meta.tombstone?.replacement_room
 		if (

--- a/web/src/api/types/mxtypes.ts
+++ b/web/src/api/types/mxtypes.ts
@@ -22,7 +22,7 @@ export type ContentURI = string
 export type RoomAlias = string
 export type ReceiptType = "m.read" | "m.read.private"
 export type RoomVersion = "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "11"
-export type RoomType = "" | "m.space" | "support.feline.policy.lists.msc.v1"
+export type RoomType = "" | "m.space" | "support.feline.policy.lists.msc.v1" | "org.matrix.msc3417.call"
 export type RelationType = "m.annotation" | "m.reference" | "m.replace" | "m.thread"
 
 export type JSONValue =


### PR DESCRIPTION
Add room type "org.matrix.msc3417.call" to the list of known rooms that are displayed in the room list.
Untested because I cannot easily compile now, but trivial patch (famous last words)