### PR TITLE
web/audio: add audio player with inline and global modes

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -27,7 +27,7 @@
 	--border-color: #ccc;
 	--pill-background-color: #ccc;
 	--disabled-input-background-color: #ddd;
-	--url-preview-background-color: rgba(0, 0, 0, .05);
+	--card-background-color: rgba(0, 0, 0, .05);
 	--highlight-pill-background-color: #c00;
 	--highlight-pill-text-color: #fff;
 	--button-hover-color: rgba(0, 0, 0, .2);
@@ -133,7 +133,7 @@
 		--border-color: #222;
 		--pill-background-color: #222;
 		--disabled-input-background-color: #222;
-		--url-preview-background-color: #222;
+		--card-background-color: #222;
 		--button-hover-color: rgba(255, 255, 255, .2);
 		--light-hover-color: rgba(255, 255, 255, .1);
 

--- a/web/src/ui/MainScreen.tsx
+++ b/web/src/ui/MainScreen.tsx
@@ -25,6 +25,7 @@ import { ensureString, ensureStringArray, parseMatrixURI } from "@/util/validati
 import ClientContext from "./ClientContext.ts"
 import MainScreenContext, { MainScreenContextFields, SetActiveRoomExtra } from "./MainScreenContext.ts"
 import StylePreferences from "./StylePreferences.tsx"
+import { AudioPlayer } from "./audio"
 import Keybindings from "./keybindings.ts"
 import { ModalContext, ModalWrapper, NestableModalContext } from "./modal"
 import RightPanel, { RightPanelProps } from "./rightpanel/RightPanel.tsx"
@@ -503,13 +504,15 @@ const MainScreen = () => {
 		</div> : null}
 	</main>
 	return <MainScreenContext value={context}>
-		<ModalWrapper ContextType={ModalContext} historyStateKey="modal">
-			<ModalWrapper ContextType={NestableModalContext} historyStateKey="nestable_modal">
-				<StylePreferences client={client} activeRoom={activeRealRoom}/>
-				{mainContent}
-				{syncLoader}
+		<AudioPlayer roomListWidth={roomListWidth} rightPanelWidth={rightPanel ? rightPanelWidth : undefined}>
+			<ModalWrapper ContextType={ModalContext} historyStateKey="modal">
+				<ModalWrapper ContextType={NestableModalContext} historyStateKey="nestable_modal">
+					<StylePreferences client={client} activeRoom={activeRealRoom}/>
+					{mainContent}
+					{syncLoader}
+				</ModalWrapper>
 			</ModalWrapper>
-		</ModalWrapper>
+		</AudioPlayer>
 	</MainScreenContext>
 }
 

--- a/web/src/ui/audio/AudioPlayer.css
+++ b/web/src/ui/audio/AudioPlayer.css
@@ -1,0 +1,137 @@
+div.global-audio-player {
+	position: fixed;
+	top: calc(var(--window-top-margin) + 3.5rem);
+	inset-inline: var(--room-list-width) var(--right-panel-width, 0);
+	height: 3rem;
+	background-color: var(--background-color);
+	border-bottom: 1px solid var(--border-color);
+	display: flex;
+	align-items: center;
+	padding: 0 .75rem;
+	z-index: 10;
+	gap: .75rem;
+
+	> div.sender-info {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		cursor: var(--clickable-cursor);
+		padding: 0.25rem;
+		margin: -0.25rem;
+		border-radius: 0.25rem;
+
+		&:hover {
+			background-color: var(--light-hover-color);
+		}
+
+		> img.avatar {
+			width: 2rem;
+			height: 2rem;
+			flex-shrink: 0;
+			border-radius: 50%;
+		}
+
+		> div.track-info {
+			display: flex;
+			flex-direction: column;
+			min-width: 0;
+			flex-shrink: 1;
+			max-width: 12rem;
+
+			> span.sender-name {
+				font-size: 0.85rem;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+			}
+
+			> span.room-name {
+				font-size: 0.75rem;
+				color: var(--secondary-text-color);
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+			}
+		}
+	}
+
+	> button {
+		width: 2rem;
+		height: 2rem;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border: none;
+		background: transparent;
+		cursor: pointer;
+		flex-shrink: 0;
+
+		&:hover {
+			background-color: var(--light-hover-color);
+		}
+
+		> svg {
+			width: 1.25rem;
+			height: 1.25rem;
+		}
+	}
+
+	> button.play-pause-btn {
+		background: var(--primary-color);
+		color: white;
+		border-radius: 50%;
+
+		&:hover {
+			opacity: 0.9;
+			background: var(--primary-color);
+		}
+
+		> svg {
+			width: 1.5rem;
+			height: 1.5rem;
+		}
+	}
+
+	> span.time {
+		font-size: 0.8rem;
+		color: var(--secondary-text-color);
+		font-variant-numeric: tabular-nums;
+		min-width: 2.5rem;
+		flex-shrink: 0;
+
+		&.current {
+			text-align: right;
+		}
+
+		&.duration {
+			text-align: left;
+		}
+	}
+
+	> div.progress-container {
+		flex: 1 1 auto;
+		min-width: 3rem;
+		height: 0.5rem;
+		background-color: var(--light-hover-color);
+		border-radius: 0.25rem;
+		cursor: pointer;
+		overflow: hidden;
+		position: relative;
+
+		> div.progress-bar {
+			position: absolute;
+			height: 100%;
+			width: 100%;
+			background-color: var(--primary-color);
+			border-radius: 0.25rem;
+			left: 0;
+			top: 0;
+			transform: translateX(-100%);
+			will-change: transform;
+		}
+	}
+
+	@media screen and (max-width: 45rem) {
+		inset-inline: 0;
+	}
+}

--- a/web/src/ui/audio/AudioPlayer.tsx
+++ b/web/src/ui/audio/AudioPlayer.tsx
@@ -1,0 +1,165 @@
+// gomuks - A Matrix client written in Go.
+// Copyright (C) 2026 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import { useCallback, useMemo, useRef, useState } from "react"
+import type { AudioMetadata, AudioPlayerContextFields } from "./AudioPlayerContext.ts"
+import AudioPlayerContext, { INITIAL_AUDIO_PLAYER_STATE } from "./AudioPlayerContext.ts"
+import PlayerControls from "./PlayerControls.tsx"
+import "./AudioPlayer.css"
+
+interface AudioPlayerProps {
+	children: React.ReactNode
+	roomListWidth?: number
+	rightPanelWidth?: number
+}
+
+const AudioPlayer = ({ children, roomListWidth, rightPanelWidth }: AudioPlayerProps) => {
+	const [state, setState] = useState(INITIAL_AUDIO_PLAYER_STATE)
+	const audioRef = useRef<HTMLAudioElement | null>(null)
+	const [globalPlayerRevealed, setGlobalPlayerRevealed] = useState(false)
+	const showGlobalPlayer = state.mediaURL !== null && globalPlayerRevealed
+
+	const revealGlobalPlayer = useCallback(() => setGlobalPlayerRevealed(true), [])
+
+	const getAudioElement = useCallback(() => audioRef.current, [])
+
+	const play = useCallback((mediaURL: string, metadata?: AudioMetadata) => {
+		if (audioRef.current && audioRef.current.src === mediaURL) {
+			audioRef.current.play()
+			return
+		}
+
+		if (audioRef.current) {
+			audioRef.current.pause()
+			audioRef.current = null
+		}
+
+		const audio = new Audio(mediaURL)
+		audioRef.current = audio
+
+		const cleanupAudioHandlers = () => {
+			audio.onloadedmetadata = null
+			audio.onplay = null
+			audio.onpause = null
+			audio.onended = null
+			audio.onerror = null
+		}
+
+		audio.onloadedmetadata = () => {
+			setState(s => ({ ...s, duration: audio.duration }))
+		}
+
+		audio.onplay = () => {
+			setState(s => ({ ...s, isPlaying: true }))
+		}
+
+		const handlePlaybackStop = () => setState(s => ({ ...s, isPlaying: false }))
+		audio.onpause = handlePlaybackStop
+		audio.onended = handlePlaybackStop
+
+		audio.onerror = () => {
+			const mediaError = audio.error
+			console.error("Audio playback failed:", {
+				src: audio.src,
+				errorCode: mediaError?.code,
+				errorMessage: mediaError?.message,
+			})
+			cleanupAudioHandlers()
+			setState(INITIAL_AUDIO_PLAYER_STATE)
+			audioRef.current = null
+		}
+
+		audio.play().catch((error: Error) => {
+			console.error("Failed to start audio playback:", {
+				name: error.name,
+				message: error.message,
+				src: audio.src,
+			})
+			cleanupAudioHandlers()
+			setState(INITIAL_AUDIO_PLAYER_STATE)
+			audioRef.current = null
+		})
+
+		setState({
+			mediaURL,
+			isPlaying: true,
+			duration: metadata?.duration ?? 0,
+			metadata: metadata ?? null,
+		})
+	}, [])
+
+	const pause = useCallback(() => {
+		audioRef.current?.pause()
+	}, [])
+
+	const resume = useCallback(() => {
+		audioRef.current?.play()?.catch((error: Error) => {
+			console.error("Failed to resume audio:", error.name, error.message)
+		})
+	}, [])
+
+	const seek = useCallback((time: number) => {
+		if (audioRef.current) {
+			audioRef.current.currentTime = time
+		}
+	}, [])
+
+	const close = useCallback(() => {
+		if (audioRef.current) {
+			audioRef.current.pause()
+			audioRef.current = null
+		}
+		setState(INITIAL_AUDIO_PLAYER_STATE)
+		setGlobalPlayerRevealed(false)
+	}, [])
+
+	const contextValue: AudioPlayerContextFields = useMemo(() => ({
+		state,
+		play,
+		pause,
+		resume,
+		seek,
+		close,
+		getAudioElement,
+		revealGlobalPlayer,
+	}), [state, play, pause, resume, seek, close, getAudioElement, revealGlobalPlayer])
+
+	return (
+		<AudioPlayerContext value={contextValue}>
+			{children}
+			{showGlobalPlayer && (
+				<PlayerControls
+					isPlaying={state.isPlaying}
+					onPlayPause={state.isPlaying ? pause : resume}
+					getAudioElement={getAudioElement}
+					isActive={showGlobalPlayer}
+					duration={state.duration}
+					onSeek={seek}
+					event={state.metadata?.event}
+					senderMemberEvent={state.metadata?.senderMemberEvent}
+					roomName={state.metadata?.roomName}
+					onClose={close}
+					className="global-audio-player"
+					style={{
+						"--room-list-width": `${roomListWidth}px`,
+						"--right-panel-width": `${rightPanelWidth ?? 0}px`,
+					} as React.CSSProperties}
+				/>
+			)}
+		</AudioPlayerContext>
+	)
+}
+
+export default AudioPlayer

--- a/web/src/ui/audio/AudioPlayerContext.ts
+++ b/web/src/ui/audio/AudioPlayerContext.ts
@@ -1,0 +1,66 @@
+// gomuks - A Matrix client written in Go.
+// Copyright (C) 2026 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import React, { createContext, use } from "react"
+import type { MemDBEvent } from "@/api/types"
+
+export const calculateClickPercent = (e: React.MouseEvent<HTMLElement>): number => {
+	const rect = e.currentTarget.getBoundingClientRect()
+	return Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width))
+}
+
+export interface AudioMetadata {
+	event: MemDBEvent
+	senderMemberEvent: MemDBEvent | null
+	roomName: string | null
+	duration?: number
+}
+
+export interface AudioPlayerState {
+	mediaURL: string | null
+	isPlaying: boolean
+	duration: number
+	metadata: AudioMetadata | null
+}
+
+export const INITIAL_AUDIO_PLAYER_STATE: AudioPlayerState = {
+	mediaURL: null,
+	isPlaying: false,
+	duration: 0,
+	metadata: null,
+}
+
+export interface AudioPlayerContextFields {
+	state: AudioPlayerState
+	play: (mediaURL: string, metadata?: AudioMetadata) => void
+	pause: () => void
+	resume: () => void
+	seek: (time: number) => void
+	close: () => void
+	getAudioElement: () => HTMLAudioElement | null
+	revealGlobalPlayer: () => void
+}
+
+const AudioPlayerContext = createContext<AudioPlayerContextFields | null>(null)
+
+export const useAudioPlayer = (): AudioPlayerContextFields => {
+	const context = use(AudioPlayerContext)
+	if (!context) {
+		throw new Error("useAudioPlayer must be used within an AudioPlayer provider")
+	}
+	return context
+}
+
+export default AudioPlayerContext

--- a/web/src/ui/audio/PlayerControls.tsx
+++ b/web/src/ui/audio/PlayerControls.tsx
@@ -1,0 +1,140 @@
+// gomuks - A Matrix client written in Go.
+// Copyright (C) 2025 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import React, { useCallback, useRef } from "react"
+import { getAvatarThumbnailURL, getUserColorIndex } from "@/api/media.ts"
+import type { MemDBEvent } from "@/api/types"
+import { formatTime } from "@/util/time.ts"
+import { getDisplayname } from "@/util/validation.ts"
+import { calculateClickPercent } from "./AudioPlayerContext.ts"
+import { useAudioAnimation } from "./useProgressBarAnimation.ts"
+import CloseIcon from "@/icons/close.svg?react"
+import PauseIcon from "@/icons/pause.svg?react"
+import PlayIcon from "@/icons/play.svg?react"
+
+interface PlayerControlsProps {
+	// Core (required)
+	isPlaying: boolean
+	onPlayPause: () => void
+	getAudioElement: () => HTMLAudioElement | null
+	isActive: boolean
+	duration: number
+	onSeek: (time: number) => void
+
+	// Optional features - event info for navigation and sender display
+	event?: MemDBEvent
+	senderMemberEvent?: MemDBEvent | null
+	roomName?: string | null
+	onClose?: () => void
+
+	// Styling
+	className?: string
+	style?: React.CSSProperties
+}
+
+const PlayerControls = ({
+	isPlaying,
+	onPlayPause,
+	getAudioElement,
+	isActive,
+	duration: initialDuration,
+	onSeek,
+	event,
+	senderMemberEvent,
+	roomName,
+	onClose,
+	className,
+	style,
+}: PlayerControlsProps) => {
+	const progressBarRef = useRef<HTMLDivElement>(null)
+	const currentTimeRef = useRef<HTMLSpanElement>(null)
+	const durationRef = useRef<HTMLSpanElement>(null)
+
+	// Derive sender info from events
+	const senderID = event?.sender
+	const senderName = senderID ? getDisplayname(senderID, senderMemberEvent?.content) : null
+	const senderAvatarURL = senderID ? getAvatarThumbnailURL(senderID, senderMemberEvent?.content) : null
+
+	const handleTrackInfoClick = useCallback(() => {
+		if (event) {
+			window.mainScreenContext.setActiveRoom(event.room_id, { openEventID: event.event_id })
+		}
+	}, [event])
+
+	useAudioAnimation({
+		getAudioElement,
+		isPlaying,
+		isActive,
+		onUpdate: (currentTime, duration, progress) => {
+			if (progressBarRef.current) {
+				progressBarRef.current.style.transform = `translateX(${(progress - 1) * 100}%)`
+			}
+			if (currentTimeRef.current) {
+				currentTimeRef.current.textContent = formatTime(currentTime)
+			}
+			if (durationRef.current && duration > 0) {
+				durationRef.current.textContent = formatTime(duration)
+			}
+		},
+	})
+
+	const handleProgressClick = (e: React.MouseEvent<HTMLDivElement>) => {
+		const percent = calculateClickPercent(e)
+		const audio = getAudioElement()
+		const duration = audio?.duration || initialDuration
+		if (duration > 0) {
+			onSeek(percent * duration)
+			if (progressBarRef.current) {
+				progressBarRef.current.style.transform = `translateX(${(percent - 1) * 100}%)`
+			}
+		}
+	}
+
+	return (
+		<div className={className} style={style}>
+			<button className="play-pause-btn" onClick={onPlayPause} title={isPlaying ? "Pause" : "Play"}>
+				{isPlaying ? <PauseIcon /> : <PlayIcon />}
+			</button>
+			{senderID && senderName && senderAvatarURL && (
+				<div className="sender-info" onClick={handleTrackInfoClick}>
+					<img
+						className="avatar"
+						loading="lazy"
+						src={senderAvatarURL}
+						alt=""
+					/>
+					<div className="track-info">
+						<span className={`sender-name sender-color-${getUserColorIndex(senderID)}`}>
+							{senderName}
+						</span>
+						{roomName && <span className="room-name">{roomName}</span>}
+					</div>
+				</div>
+			)}
+			<span ref={currentTimeRef} className="time">{formatTime(0)}</span>
+			<div className="progress-container" onClick={handleProgressClick}>
+				<div ref={progressBarRef} className="progress-bar" />
+			</div>
+			<span ref={durationRef} className="time">{formatTime(initialDuration)}</span>
+			{onClose && (
+				<button className="close-btn" onClick={onClose} title="Close">
+					<CloseIcon />
+				</button>
+			)}
+		</div>
+	)
+}
+
+export default PlayerControls

--- a/web/src/ui/audio/index.ts
+++ b/web/src/ui/audio/index.ts
@@ -1,0 +1,22 @@
+// gomuks - A Matrix client written in Go.
+// Copyright (C) 2026 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+export { default as AudioPlayer } from "./AudioPlayer.tsx"
+export { default as PlayerControls } from "./PlayerControls.tsx"
+export {
+	INITIAL_AUDIO_PLAYER_STATE, calculateClickPercent, default as AudioPlayerContext, useAudioPlayer,
+} from "./AudioPlayerContext.ts"
+export type { AudioMetadata, AudioPlayerContextFields, AudioPlayerState } from "./AudioPlayerContext.ts"
+export { useAudioAnimation } from "./useProgressBarAnimation.ts"

--- a/web/src/ui/audio/useProgressBarAnimation.ts
+++ b/web/src/ui/audio/useProgressBarAnimation.ts
@@ -1,0 +1,61 @@
+// gomuks - A Matrix client written in Go.
+// Copyright (C) 2026 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import { useEffect, useRef } from "react"
+
+interface UseAudioAnimationOptions {
+	getAudioElement: () => HTMLAudioElement | null
+	isPlaying: boolean
+	isActive: boolean
+	onUpdate: (currentTime: number, duration: number, progress: number) => void
+}
+
+export function useAudioAnimation({
+	getAudioElement,
+	isPlaying,
+	isActive,
+	onUpdate,
+}: UseAudioAnimationOptions): void {
+	const animationFrameRef = useRef<number | null>(null)
+	const onUpdateRef = useRef(onUpdate)
+	onUpdateRef.current = onUpdate
+
+	useEffect(() => {
+		if (!isPlaying || !isActive) {
+			if (animationFrameRef.current) {
+				cancelAnimationFrame(animationFrameRef.current)
+				animationFrameRef.current = null
+			}
+			return
+		}
+
+		const update = () => {
+			const audio = getAudioElement()
+			if (audio) {
+				const progress = audio.duration > 0 ? audio.currentTime / audio.duration : 0
+				onUpdateRef.current(audio.currentTime, audio.duration, progress)
+			}
+			animationFrameRef.current = requestAnimationFrame(update)
+		}
+
+		animationFrameRef.current = requestAnimationFrame(update)
+
+		return () => {
+			if (animationFrameRef.current) {
+				cancelAnimationFrame(animationFrameRef.current)
+			}
+		}
+	}, [isPlaying, isActive, getAudioElement])
+}

--- a/web/src/ui/modal/Lightbox.css
+++ b/web/src/ui/modal/Lightbox.css
@@ -1,6 +1,7 @@
 div.overlay {
 	position: fixed;
 	inset: 0;
+	z-index: 100;
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/web/src/ui/timeline/content/AudioMessage.tsx
+++ b/web/src/ui/timeline/content/AudioMessage.tsx
@@ -39,14 +39,14 @@ const AudioMessage = ({
 	const initialDurationSec = initialDurationMs ? initialDurationMs / 1000 : 0
 
 	const { revealGlobalPlayer } = audioPlayer
-	const isThisTrackRef = useRef(isThisTrack)
-	isThisTrackRef.current = isThisTrack
+	const isPlayingRef = useRef(isPlaying)
+	isPlayingRef.current = isPlaying
 
-	// Reveal global player only when this component unmounts while playing this track
+	// Reveal global player only when this component unmounts while actively playing
 	// (e.g., when scrolling away from the message)
 	useEffect(() => {
 		return () => {
-			if (isThisTrackRef.current) {
+			if (isPlayingRef.current) {
 				revealGlobalPlayer()
 			}
 		}

--- a/web/src/ui/timeline/content/AudioMessage.tsx
+++ b/web/src/ui/timeline/content/AudioMessage.tsx
@@ -1,0 +1,92 @@
+// gomuks - A Matrix client written in Go.
+// Copyright (C) 2026 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import { useEffect, useRef } from "react"
+import type { MemDBEvent } from "@/api/types"
+import type { AudioMetadata } from "@/ui/audio"
+import { PlayerControls, useAudioPlayer } from "@/ui/audio"
+
+export interface AudioMessageProps {
+	src: string
+	duration?: number
+	event?: MemDBEvent
+	senderMemberEvent?: MemDBEvent | null
+	roomName?: string | null
+}
+
+const AudioMessage = ({
+	src,
+	duration: initialDurationMs,
+	event,
+	senderMemberEvent,
+	roomName,
+}: AudioMessageProps) => {
+	const audioPlayer = useAudioPlayer()
+	const isThisTrack = audioPlayer.state.mediaURL === src
+	const isPlaying = isThisTrack && audioPlayer.state.isPlaying
+	const initialDurationSec = initialDurationMs ? initialDurationMs / 1000 : 0
+
+	const { revealGlobalPlayer } = audioPlayer
+	const isThisTrackRef = useRef(isThisTrack)
+	isThisTrackRef.current = isThisTrack
+
+	// Reveal global player only when this component unmounts while playing this track
+	// (e.g., when scrolling away from the message)
+	useEffect(() => {
+		return () => {
+			if (isThisTrackRef.current) {
+				revealGlobalPlayer()
+			}
+		}
+	}, [revealGlobalPlayer])
+
+	const handlePlayPause = () => {
+		if (isThisTrack) {
+			if (isPlaying) {
+				audioPlayer.pause()
+			} else {
+				audioPlayer.resume()
+			}
+		} else {
+			const metadata: AudioMetadata | undefined = event ? {
+				event,
+				senderMemberEvent: senderMemberEvent ?? null,
+				roomName: roomName ?? null,
+				duration: initialDurationSec,
+			} : undefined
+			audioPlayer.play(src, metadata)
+		}
+	}
+
+	const handleSeek = (time: number) => {
+		if (isThisTrack) {
+			audioPlayer.seek(time)
+		}
+	}
+
+	return (
+		<PlayerControls
+			isPlaying={isPlaying}
+			onPlayPause={handlePlayPause}
+			getAudioElement={audioPlayer.getAudioElement}
+			isActive={isThisTrack}
+			duration={initialDurationSec}
+			onSeek={handleSeek}
+			className="audio-message-player"
+		/>
+	)
+}
+
+export default AudioMessage

--- a/web/src/ui/timeline/content/MediaMessageBody.tsx
+++ b/web/src/ui/timeline/content/MediaMessageBody.tsx
@@ -68,8 +68,9 @@ const MediaMessageBody = ({ event, room, sender }: EventContentProps) => {
 	const isLoadingOnlyCover = !loaded && !contentWarning && renderMediaElem
 
 	const containerSize = imageWidth === 320 ? undefined : { width: imageWidth, height: imageWidth / 4 * 3 }
-	const [mediaContent, containerClass, containerStyle] =
-		useMediaContent(content, event.type, containerSize, onLoad, autoplayGifs)
+	const [mediaContent, containerClass, containerStyle] = useMediaContent(
+		content, event.type, containerSize, onLoad, autoplayGifs, { event, room, senderMemberEvent: sender },
+	)
 
 	let placeholderElem: JSX.Element | null = null
 	if (renderPlaceholderElem) {

--- a/web/src/ui/timeline/content/index.css
+++ b/web/src/ui/timeline/content/index.css
@@ -391,3 +391,76 @@ div.poll-body {
 		}
 	}
 }
+
+div.audio-message-player {
+	display: flex;
+	align-items: center;
+	gap: .5rem;
+	padding: .5rem;
+	background-color: var(--card-background-color);
+	border: 1px solid var(--border-color);
+	border-radius: .5rem;
+	min-width: 250px;
+	max-width: 350px;
+
+	> button.play-pause-btn {
+		width: 2.5rem;
+		height: 2.5rem;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border: none;
+		background: var(--primary-color);
+		color: white;
+		cursor: pointer;
+		border-radius: 50%;
+		flex-shrink: 0;
+
+		&:hover {
+			opacity: 0.9;
+		}
+
+		> svg {
+			width: 1.25rem;
+			height: 1.25rem;
+		}
+	}
+
+	> span.time {
+		font-size: 0.75rem;
+		color: var(--secondary-text-color);
+		font-variant-numeric: tabular-nums;
+		min-width: 2.5rem;
+		flex-shrink: 0;
+
+		&:first-of-type {
+			text-align: right;
+		}
+
+		&:last-of-type {
+			text-align: left;
+		}
+	}
+
+	> div.progress-container {
+		flex: 1;
+		height: 0.5rem;
+		background-color: var(--light-hover-color);
+		border-radius: 0.25rem;
+		cursor: pointer;
+		overflow: hidden;
+		position: relative;
+
+		> div.progress-bar {
+			position: absolute;
+			height: 100%;
+			width: 100%;
+			background-color: var(--primary-color);
+			border-radius: 0.25rem;
+			left: 0;
+			top: 0;
+			transform: translateX(-100%);
+			will-change: transform;
+		}
+	}
+}

--- a/web/src/ui/timeline/content/useMediaContent.tsx
+++ b/web/src/ui/timeline/content/useMediaContent.tsx
@@ -1,5 +1,5 @@
 // gomuks - A Matrix client written in Go.
-// Copyright (C) 2024 Tulir Asokan
+// Copyright (C) 2026 Tulir Asokan
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -15,11 +15,19 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import React, { CSSProperties, JSX, use, useState } from "react"
 import { getEncryptedMediaURL, getMediaURL } from "@/api/media.ts"
-import type { EventType, MediaMessageEventContent } from "@/api/types"
+import type { RoomStateStore } from "@/api/statestore"
+import type { EventType, MediaMessageEventContent, MemDBEvent } from "@/api/types"
 import { ImageContainerSize, calculateMediaSize, defaultVideoContainerSize } from "@/util/mediasize.ts"
 import { ensureString } from "@/util/validation.ts"
 import { LightboxContext } from "../../modal"
+import AudioMessage from "./AudioMessage.tsx"
 import DownloadIcon from "@/icons/download.svg?react"
+
+export interface MediaContext {
+	event: MemDBEvent
+	room: RoomStateStore
+	senderMemberEvent: MemDBEvent | null
+}
 
 export const useMediaContent = (
 	content: MediaMessageEventContent,
@@ -27,6 +35,7 @@ export const useMediaContent = (
 	containerSize?: ImageContainerSize,
 	onLoad?: () => void,
 	autoplayGifs?: boolean,
+	mediaContext?: MediaContext,
 ): [JSX.Element | null, string, CSSProperties] => {
 	const mediaURL = content.file?.url ? getEncryptedMediaURL(content.file.url) : getMediaURL(content.url)
 	const thumbnailURL = content.info?.thumbnail_file?.url
@@ -77,7 +86,23 @@ export const useMediaContent = (
 			<source src={mediaURL} type={ensureString(content.info?.mimetype)}/>
 		</video>, "video-container", style.container]
 	} else if (content.msgtype === "m.audio") {
-		return [<audio controls src={mediaURL} preload="none"/>, "audio-container", {}]
+		if (!mediaURL) {
+			return [null, "audio-container", {}]
+		}
+		const roomName = mediaContext?.room.meta.current.dm_user_id
+			? null
+			: mediaContext?.room.meta.current.name ?? null
+		return [
+			<AudioMessage
+				src={mediaURL}
+				duration={content.info?.duration as number | undefined}
+				event={mediaContext?.event}
+				senderMemberEvent={mediaContext?.senderMemberEvent}
+				roomName={roomName}
+			/>,
+			"audio-container",
+			{},
+		]
 	} else if (content.msgtype === "m.file") {
 		return [<a
 			href={mediaURL}

--- a/web/src/ui/urlpreview/URLPreview.css
+++ b/web/src/ui/urlpreview/URLPreview.css
@@ -1,8 +1,8 @@
 div.url-preview {
 	margin: 0.5rem 0;
 	border-radius: 0.5rem;
-	background-color: var(--url-preview-background-color);
-	border: 1px solid var(--url-preview-background-color);
+	background-color: var(--card-background-color);
+	border: 1px solid var(--card-background-color);
 	display: grid;
 	flex-shrink: 0;
 

--- a/web/src/ui/util/jumpToEvent.tsx
+++ b/web/src/ui/util/jumpToEvent.tsx
@@ -20,6 +20,7 @@ import { RoomContextData } from "../roomview/roomcontext.ts"
 export const jumpToEvent = (roomCtx: RoomContextData, evtID: EventID, allowRetry: boolean = true) => {
 	if (jumpToVisibleEvent(evtID, null, roomCtx)) {
 		console.info("Jumped to event", evtID, "in visible timeline")
+		roomCtx.scrolledToBottom = false
 	} else if (roomCtx.store.timeline.length === 0 && allowRetry) {
 		// Hacky sleep to let the timeline load maybe?
 		console.info("Waiting for timeline to load before jumping to event", evtID)

--- a/web/src/util/time.ts
+++ b/web/src/util/time.ts
@@ -1,0 +1,22 @@
+// gomuks - A Matrix client written in Go.
+// Copyright (C) 2026 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+export const formatTime = (seconds: number): string => {
+	if (!isFinite(seconds) || seconds < 0) {return "0:00"}
+	const mins = Math.floor(seconds / 60)
+	const secs = Math.floor(seconds % 60)
+	return `${mins}:${secs.toString().padStart(2, "0")}`
+}


### PR DESCRIPTION
Replaces native audio controls with a custom player. Features:

- Inline player embedded in audio messages
- Global floating player appears when scrolling away while audio is playing
- Clicking sender info in global player navigates back to the message

Also includes:
- Rename `--url-preview-background-color` to `--card-background-color` for reuse
- Fix scroll position being overridden after jumping to an event
- Fix lightbox z-index to appear above the global player