### PR TITLE
web/keybindings: use escape to close active room view

### DIFF
--- a/web/src/ui/composer/MessageComposer.tsx
+++ b/web/src/ui/composer/MessageComposer.tsx
@@ -448,6 +448,7 @@ const MessageComposer = () => {
 			if (autocompleteUpdate !== undefined) {
 				setAutocomplete(autocompleteUpdate && { ...autocomplete, ...autocompleteUpdate })
 				evt.preventDefault()
+				evt.stopPropagation()
 			}
 		} else if (fullKey === "ArrowUp" && inp.selectionStart === 0 && inp.selectionEnd === 0) {
 			const currentlyEditing = editing

--- a/web/src/ui/keybindings.ts
+++ b/web/src/ui/keybindings.ts
@@ -41,6 +41,7 @@ export default class Keybindings {
 	constructor(private store: StateStore, private context: MainScreenContextFields) {}
 
 	private keyDownMap: KeyMap = {
+		"Escape": () => this.context.clearActiveRoom(),
 		"Ctrl+k": () => document.getElementById("room-search")?.focus(),
 		"Alt+ArrowUp": () => {
 			if (!this.activeRoom) {
@@ -69,7 +70,6 @@ export default class Keybindings {
 	}
 
 	private keyUpMap: KeyMap = {
-		// "Escape": evt => evt.target === evt.currentTarget && this.context.clearActiveRoom(),
 	}
 
 	listen(): () => void {


### PR DESCRIPTION
Simple fix to re-enable Escape hotkey, tested locally

---

Move the Escape handler from keyUpMap to keyDownMap. The original keyUpMap placement caused conflicts with modal/lightbox: pressing Escape to close a lightbox would fire keydown on the overlay (which stopPropagates and closes it), then keyup on body (lightbox gone, focus returned) would clear the room as a side effect.

On keyDownMap, all overlay handlers (Modal, Lightbox, RoomList search) call stopPropagation on keydown, so the event never reaches the body listener when those are open.

Also add stopPropagation to the composer's autocomplete Escape handler to prevent it from bubbling up to the body-level clearActiveRoom.