### PR TITLE
web/timeline: fix unloaded video size when thumbnail has lower resolution than actual video

### DIFF
--- a/web/src/ui/timeline/content/index.css
+++ b/web/src/ui/timeline/content/index.css
@@ -257,6 +257,10 @@ div.media-container {
 			background-color: var(--media-placeholder-default-background);
 		}
 	}
+
+	> video {
+		width: 100%;
+	}
 }
 
 iframe.location-container.google {


### PR DESCRIPTION
Unlike other file types, for some reason, video previews did not scale properly with it until I actually click to play, which looks very bad in UI

Before:
<img width="495" height="657" alt="image" src="https://github.com/user-attachments/assets/05da1b3c-c4ed-4c0a-9471-56a9c48c1026" />

After:
<img width="416" height="651" alt="image" src="https://github.com/user-attachments/assets/86d6ef28-cafd-4f40-bc7d-fc35bc2899c4" />


---

`<video>` elements with `poster` + `preload="none"` render at the browser's default 300x150px rather than filling the calculated container, causing video thumbnails to appear much smaller than the configured `max_image_width` — with visible dead space between the poster and caption. Clicking play expands the video to full size as the intrinsic dimensions become available.

Images don't have this issue because `loading="lazy"` provides intrinsic dimensions once the image loads. Videos with `preload="none"` never fetch the source to discover dimensions, so the `<video>` element falls back to the HTML spec default.

Fix: add `width: 100%` to `div.media-container > video` in CSS. The container already has correct dimensions via `calculateMediaSize` + `contain: strict`, so the video fills the container width and `aspectRatio` + `max-height: 100%` handle height correctly.
