### PR TITLE
hicli/sync: include preview sender member in incremental sync

### DIFF
--- a/pkg/hicli/sync.go
+++ b/pkg/hicli/sync.go
@@ -860,6 +860,7 @@ func (h *HiClient) processStateAndTimeline(
 	addedEvents := make(map[database.EventRowID]struct{})
 	newNotifications := make([]jsoncmd.SyncNotification, 0)
 	var recalculatePreviewEvent, unreadMessagesWereMaybeRedacted bool
+	var previewSender id.UserID
 	var newUnreadCounts database.UnreadCounts
 	addOldEvent := func(rowID database.EventRowID, evtID id.EventID) (dbEvt *database.Event, err error) {
 		if rowID != 0 {
@@ -924,6 +925,7 @@ func (h *HiClient) processStateAndTimeline(
 		if isTimeline {
 			if dbEvt.CanUseForPreview() {
 				updatedRoom.PreviewEventRowID = dbEvt.RowID
+				previewSender = evt.Sender
 				recalculatePreviewEvent = false
 			}
 			updatedRoom.BumpSortingTimestamp(dbEvt)
@@ -1083,9 +1085,35 @@ func (h *HiClient) processStateAndTimeline(
 		if err != nil {
 			return fmt.Errorf("failed to recalculate preview event: %w", err)
 		} else if updatedRoom.PreviewEventRowID != 0 {
-			_, err = addOldEvent(updatedRoom.PreviewEventRowID, "")
+			recalcEvt, err := addOldEvent(updatedRoom.PreviewEventRowID, "")
 			if err != nil {
 				return fmt.Errorf("failed to get preview event: %w", err)
+			}
+			if recalcEvt != nil {
+				previewSender = recalcEvt.Sender
+			}
+		}
+	}
+	// Ensure the preview sender's member event is included in the sync payload when
+	// the preview event changes. The initial sync does this explicitly (init.go), but
+	// incremental syncs may not include the member if the homeserver already lazy-loaded
+	// it in a previous sync session before the frontend connected.
+	if previewSender != "" && updatedRoom.PreviewEventRowID != room.PreviewEventRowID {
+		senderStr := previewSender.String()
+		memberMap := changedState[event.StateMember]
+		if memberMap == nil || memberMap[senderStr] == 0 {
+			memberEvt, err := h.DB.CurrentState.Get(ctx, room.ID, event.StateMember, senderStr)
+			if err != nil {
+				zerolog.Ctx(ctx).Warn().Err(err).
+					Stringer("room_id", room.ID).
+					Stringer("sender", previewSender).
+					Msg("Failed to get preview sender member event")
+			} else if memberEvt != nil {
+				if _, alreadyAdded := addedEvents[memberEvt.RowID]; !alreadyAdded {
+					allNewEvents = append(allNewEvents, memberEvt)
+					addedEvents[memberEvt.RowID] = struct{}{}
+				}
+				setNewState(event.StateMember, *memberEvt.StateKey, memberEvt.RowID)
 			}
 		}
 	}


### PR DESCRIPTION
Very annoying bug with display names not showing up correctly, presumably due to lazy load, until I actually click on the room:

<img width="271" height="183" alt="image" src="https://github.com/user-attachments/assets/76d30884-5a7a-4011-a40f-7503fa20fe7a" />

You obviously know better how your stuff works, but this fix seem to work for me, so I suggest it.

Before:
<img width="315" height="99" alt="image" src="https://github.com/user-attachments/assets/1912edab-01fe-421b-ae26-7d2da849053f" />

After:
<img width="325" height="105" alt="image" src="https://github.com/user-attachments/assets/5ce995fd-f049-4107-ad83-c6ecea623b15" />

---

**Claude analysis**: preview sender display name missing in room list

The room list sometimes shows raw user IDs (e.g. `telegram_450...`) instead of display
names for the last message sender. Clicking the room resolves it.

**Cause:** The initial sync (`init.go:43-51`) explicitly includes the preview sender's
member event. Incremental syncs don't — when a new message changes the preview to a
different sender whose member was lazy-loaded in a previous `/sync` session (before the
current frontend connected), the frontend never receives it.

**Fix:** After finalizing the preview event in the incremental sync path (`sync.go`),
check if the new sender's member is already in the payload. If not, fetch it from the
DB and include it — mirroring what `init.go` already does.

Tracks a `previewSender` local var set at both assignment sites (timeline + recalculation
after redaction) to avoid scanning `allNewEvents`. Uses `*memberEvt.StateKey` for the
state key, matching `init.go`'s pattern.

Verified via CDP: all 136 rooms resolve preview senders correctly after the fix.
