### PR TITLE
web/composer: fix command autocomplete closing during arrow navigation

### DIFF
--- a/web/src/ui/composer/Autocompleter.tsx
+++ b/web/src/ui/composer/Autocompleter.tsx
@@ -122,11 +122,11 @@ function useAutocompleter<T>({
 		if (params.type !== "command" || !state.text) {
 			return
 		}
-		if (isFakeCommand(state.text)) {
+		if (isFakeCommand(state.text) && !params.frozenQuery) {
 			// Special case commands that don't use MSC4332
 			setAutocomplete(null)
 			return
-		} else if (items.length === 0 && prevItems.current?.length) {
+		} else if (items.length === 0 && prevItems.current?.length && !params.frozenQuery) {
 			for (const item of prevItems.current as WrappedBotCommand[]) {
 				const argVals = stringToCommandArgs(item, state.text)
 				if (argVals !== null) {
@@ -155,7 +155,7 @@ function useAutocompleter<T>({
 			}
 		}
 		prevItems.current = items
-	}, [params.type, items, state.text, setAutocomplete, setState])
+	}, [params.type, params.frozenQuery, items, state.text, setAutocomplete, setState])
 	const selected = params.selected !== undefined ? positiveMod(params.selected, items.length) : -1
 	return <div
 		className={`autocompletions ac-${params.type} ${items.length === 0 ? "empty" : "has-items"}`}
@@ -268,7 +268,7 @@ const commandFuncs = {
 		if (state.text.charAt(firstArgPos) === `"` || state.text.charAt(firstArgPos) === `<`) {
 			firstArgPos++
 		}
-		return [state, firstArgPos || state.text.length] as const
+		return [state, Math.min(firstArgPos, state.text.length)] as const
 	},
 	render: (cmd: WrappedBotCommand) => <>
 		<BotSourceIcon source={cmd.source} />

--- a/web/src/ui/composer/MessageComposer.tsx
+++ b/web/src/ui/composer/MessageComposer.tsx
@@ -370,10 +370,14 @@ const MessageComposer = () => {
 			return
 		}
 		if (autocomplete?.frozenQuery) {
-			// For commands, don't close on caret mismatch during navigation —
-			// onSelect manages the text and caret, but keyUp may fire with a
-			// stale caret position.
-			if (autocomplete.type !== "command" && area.selectionEnd !== autocomplete.endPos) {
+			if (autocomplete.type === "command") {
+				// For commands, don't close on caret mismatch during arrow navigation.
+				// But if the user is typing (newText from onChange), clear frozenQuery
+				// so the normal command detection flow resumes.
+				if (newText !== undefined) {
+					setAutocomplete({ ...autocomplete, frozenQuery: undefined, endPos: newText.length })
+				}
+			} else if (area.selectionEnd !== autocomplete.endPos) {
 				setAutocomplete(null)
 			}
 		} else if (autocomplete) {

--- a/web/src/ui/composer/MessageComposer.tsx
+++ b/web/src/ui/composer/MessageComposer.tsx
@@ -442,7 +442,7 @@ const MessageComposer = () => {
 				autocompleteUpdate = { selected: autocomplete.selected ?? 0, close: true }
 			} else if (fullKey === "Escape") {
 				autocompleteUpdate = null
-				if (autocomplete.frozenQuery) {
+				if (autocomplete.frozenQuery && autocomplete.type !== "command") {
 					setState({
 						text: state.text.slice(0, autocomplete.startPos)
 							+ autocomplete.frozenQuery

--- a/web/src/ui/composer/MessageComposer.tsx
+++ b/web/src/ui/composer/MessageComposer.tsx
@@ -370,7 +370,10 @@ const MessageComposer = () => {
 			return
 		}
 		if (autocomplete?.frozenQuery) {
-			if (area.selectionEnd !== autocomplete.endPos) {
+			// For commands, don't close on caret mismatch during navigation —
+			// onSelect manages the text and caret, but keyUp may fire with a
+			// stale caret position.
+			if (autocomplete.type !== "command" && area.selectionEnd !== autocomplete.endPos) {
 				setAutocomplete(null)
 			}
 		} else if (autocomplete) {

--- a/web/src/ui/composer/MessageComposer.tsx
+++ b/web/src/ui/composer/MessageComposer.tsx
@@ -446,13 +446,17 @@ const MessageComposer = () => {
 				autocompleteUpdate = { selected: autocomplete.selected ?? 0, close: true }
 			} else if (fullKey === "Escape") {
 				autocompleteUpdate = null
-				if (autocomplete.frozenQuery && autocomplete.type !== "command") {
-					setState({
-						text: state.text.slice(0, autocomplete.startPos)
-							+ autocomplete.frozenQuery
-							+ state.text.slice(autocomplete.endPos),
-						command: null,
-					})
+				if (autocomplete.frozenQuery) {
+					if (autocomplete.type === "command") {
+						setState({ text: autocomplete.frozenQuery, command: null })
+					} else {
+						setState({
+							text: state.text.slice(0, autocomplete.startPos)
+								+ autocomplete.frozenQuery
+								+ state.text.slice(autocomplete.endPos),
+							command: null,
+						})
+					}
 				}
 			}
 			if (autocompleteUpdate !== undefined) {


### PR DESCRIPTION
I honestly don't know what the correct or expected behavior in a bunch of these cases is supposed to be. See video below and let me know I guess.


https://github.com/user-attachments/assets/b75c52f1-a9e4-48d9-a45d-146245ee746b

---
<details>
  <summary><b>Claude's description</b></summary>

Browsing commands with ArrowDown/Up auto-selects no-arg commands (like `/leave`) and fake commands (like `/plain`), closing the autocomplete list instead of just highlighting them.

Fixes:
- Guard `isFakeCommand` and items-empty close paths with `frozenQuery` so they only fire during manual typing, not arrow navigation.
- Clamp `endPos` with `Math.min` for no-arg commands (was exceeding text length)
- Skip caret mismatch check for commands during navigation
- Clear `frozenQuery` when the user starts typing so command detection resumes
- Skip broken text restore on Escape for commands (just close the list instead)
</details>