### PR TITLE
web/api: immediately retry the websocket connection on window focus

### DIFF
--- a/web/src/api/wsclient.ts
+++ b/web/src/api/wsclient.ts
@@ -62,6 +62,16 @@ export default class WSClient extends RPCClient {
 
 	constructor(readonly addr: string, readonly compress: boolean = false) {
 		super()
+		window.addEventListener("focus", this.#onFocus)
+	}
+
+	#onFocus = () => {
+		if (this.#reconnectTimeout !== null) {
+			console.log("Window focused, reconnecting immediately")
+			clearTimeout(this.#reconnectTimeout)
+			this.#reconnectTimeout = null
+			this.start()
+		}
 	}
 
 	start() {


### PR DESCRIPTION
Primarily fixes issues caused by backgrounding on mobile

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
