### PR TITLE
web/composer: make replying state clear when hitting escape

### DIFF
--- a/web/src/ui/composer/MessageComposer.tsx
+++ b/web/src/ui/composer/MessageComposer.tsx
@@ -489,18 +489,24 @@ const MessageComposer = () => {
 				evt.preventDefault()
 			}
 		} else if (
-			!editing && fullKey === "Ctrl+ArrowDown" && replyToEvt !== null && room.preferences.ctrl_arrow_reply
+			!editing && replyToEvt !== null && room.preferences.ctrl_arrow_reply
 		) {
-			const replyToIdx = room.timeline.findIndex(item => item.event_rowid === replyToEvt.rowid)
-			if (replyToIdx >= room.timeline.length - 1) {
-				roomCtx.setReplyTo(null)
-				evt.preventDefault()
-			} else if (replyToIdx >= 0) {
-				const newReplyEvt = room.eventsByRowID.get(room.timeline[replyToIdx + 1].event_rowid)
-				if (newReplyEvt) {
-					roomCtx.setReplyTo(newReplyEvt.event_id)
+			// Actively Replying
+			if (fullKey === "Ctrl+ArrowDown") {
+				const replyToIdx = room.timeline.findIndex(item => item.event_rowid === replyToEvt.rowid)
+				if (replyToIdx >= room.timeline.length - 1) {
+					roomCtx.setReplyTo(null)
 					evt.preventDefault()
+				} else if (replyToIdx >= 0) {
+					const newReplyEvt = room.eventsByRowID.get(room.timeline[replyToIdx + 1].event_rowid)
+					if (newReplyEvt) {
+						roomCtx.setReplyTo(newReplyEvt.event_id)
+						evt.preventDefault()
+					}
 				}
+			} else if (fullKey === "Escape") {
+				evt.stopPropagation()
+				roomCtx.setReplyTo(null)
 			}
 		}
 	}

--- a/web/src/ui/composer/MessageComposer.tsx
+++ b/web/src/ui/composer/MessageComposer.tsx
@@ -489,10 +489,12 @@ const MessageComposer = () => {
 				evt.preventDefault()
 			}
 		} else if (
-			!editing && replyToEvt !== null && room.preferences.ctrl_arrow_reply
+			!editing && replyToEvt !== null
 		) {
 			// Actively Replying
-			if (fullKey === "Ctrl+ArrowDown") {
+			if (
+				fullKey === "Ctrl+ArrowDown" && room.preferences.ctrl_arrow_reply
+			) {
 				const replyToIdx = room.timeline.findIndex(item => item.event_rowid === replyToEvt.rowid)
 				if (replyToIdx >= room.timeline.length - 1) {
 					roomCtx.setReplyTo(null)


### PR DESCRIPTION
Made the replying state of the message composer clear when pressing escape. This happened before with editing messages, but not replies.

### Checklist

* [X] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
