### PR TITLE
Separate reply and thread buttons

### DIFF
--- a/web/src/ui/composer/MessageComposer.tsx
+++ b/web/src/ui/composer/MessageComposer.tsx
@@ -186,6 +186,10 @@ const MessageComposer = () => {
 		setState({ replyTo: evt, silentReply: false, explicitReplyInThread: false, startNewThread: false })
 		textInput.current?.focus()
 	}, [])
+	roomCtx.setReplyToAsThread = useCallback((evt: EventID) => {
+		setState({ replyTo: evt, silentReply: false, explicitReplyInThread: false, startNewThread: true })
+		textInput.current?.focus()
+	}, [])
 	const setSilentReply = useCallback((newVal: boolean | React.MouseEvent) => {
 		if (typeof newVal === "boolean") {
 			setState({ silentReply: newVal })

--- a/web/src/ui/keybindings.ts
+++ b/web/src/ui/keybindings.ts
@@ -43,6 +43,7 @@ export default class Keybindings {
 	private keyDownMap: KeyMap = {
 		"Escape": () => this.context.clearActiveRoom(),
 		"Ctrl+k": () => document.getElementById("room-search")?.focus(),
+		"Super+k": () => document.getElementById("room-search")?.focus(),
 		"Alt+ArrowUp": () => {
 			if (!this.activeRoom) {
 				return

--- a/web/src/ui/keybindings.ts
+++ b/web/src/ui/keybindings.ts
@@ -43,7 +43,6 @@ export default class Keybindings {
 	private keyDownMap: KeyMap = {
 		"Escape": () => this.context.clearActiveRoom(),
 		"Ctrl+k": () => document.getElementById("room-search")?.focus(),
-		"Super+k": () => document.getElementById("room-search")?.focus(),
 		"Alt+ArrowUp": () => {
 			if (!this.activeRoom) {
 				return

--- a/web/src/ui/menu/usePrimaryItems.tsx
+++ b/web/src/ui/menu/usePrimaryItems.tsx
@@ -28,6 +28,7 @@ import MoreIcon from "@/icons/more.svg?react"
 import ReactIcon from "@/icons/react.svg?react"
 import RefreshIcon from "@/icons/refresh.svg?react"
 import ReplyIcon from "@/icons/reply.svg?react"
+import ThreadIcon from "@/icons/thread.svg?react"
 import "./index.css"
 
 const noop = () => {}
@@ -47,6 +48,10 @@ export const usePrimaryItems = (
 
 	const onClickReply = () => {
 		roomCtx.setReplyTo(evt.event_id)
+		closeModal()
+	}
+	const onClickThread = () => {
+		roomCtx.setReplyToAsThread(evt.event_id)
 		closeModal()
 	}
 	const onClickReact = (mevt: React.MouseEvent<HTMLButtonElement>) => {
@@ -134,6 +139,14 @@ export const usePrimaryItems = (
 		>
 			<ReplyIcon/>
 			{names && "Reply"}
+		</button>}
+		{canSend && !roomCtx.threadRoot && <button
+			disabled={isEditing || isPending}
+			title={isEditing ? "Can't start a thread while editing a message" : (pendingTitle || "Start new thread")}
+			onClick={onClickThread}
+		>
+			<ThreadIcon/>
+			{names && "Thread"}
 		</button>}
 		{canEdit && <button onClick={onClickEdit} disabled={isPending} title={pendingTitle}>
 			<EditIcon/>

--- a/web/src/ui/roomlist/RoomList.tsx
+++ b/web/src/ui/roomlist/RoomList.tsx
@@ -135,7 +135,14 @@ const RoomList = ({ activeRoomID, space }: RoomListProps) => {
 
 	const showInviteAvatars = usePreference(client.store, null, "show_invite_avatars")
 	const roomListFilter = client.store.roomListFilterFunc
-	return <div className="room-list-wrapper">
+	const onWrapperKeyDown = (evt: React.KeyboardEvent<HTMLDivElement>) => {
+		if (keyToString(evt) === "Escape" && query !== "") {
+			clearQuery()
+			evt.stopPropagation()
+			evt.preventDefault()
+		}
+	}
+	return <div className="room-list-wrapper" onKeyDown={onWrapperKeyDown}>
 		<div className="room-search-wrapper">
 			<input
 				value={query}

--- a/web/src/ui/roomlist/RoomList.tsx
+++ b/web/src/ui/roomlist/RoomList.tsx
@@ -127,9 +127,7 @@ const RoomList = ({ activeRoomID, space }: RoomListProps) => {
 		} else if (key === "Enter") {
 			const roomList = client.store.getFilteredRoomList()
 			mainScreen.setActiveRoom(roomList[roomList.length-1]?.room_id)
-			client.store.currentRoomListQuery = ""
-			directSetQuery("")
-			requestAnimationFrame(() => document.getElementById("message-composer")?.focus())
+			clearQuery()
 			evt.stopPropagation()
 			evt.preventDefault()
 		}

--- a/web/src/ui/roomlist/RoomList.tsx
+++ b/web/src/ui/roomlist/RoomList.tsx
@@ -135,7 +135,9 @@ const RoomList = ({ activeRoomID, space }: RoomListProps) => {
 		if (key === "Enter") {
 			const roomList = client.store.getFilteredRoomList()
 			mainScreen.setActiveRoom(roomList[roomList.length-1]?.room_id)
-			clearQuery()
+			client.store.currentRoomListQuery = ""
+			directSetQuery("")
+			requestAnimationFrame(() => document.getElementById("message-composer")?.focus())
 			evt.stopPropagation()
 			evt.preventDefault()
 		}

--- a/web/src/ui/roomlist/RoomList.tsx
+++ b/web/src/ui/roomlist/RoomList.tsx
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-import React, { use, useCallback, useEffect, useRef, useState } from "react"
+import React, { use, useCallback, useRef, useState } from "react"
 import { BarLoader } from "react-spinners"
 import { getAvatarThumbnailURL } from "@/api/media.ts"
 import { RoomListFilter, Space as SpaceStore, SpaceUnreadCounts, usePreference } from "@/api/statestore"
@@ -113,26 +113,18 @@ const RoomList = ({ activeRoomID, space }: RoomListProps) => {
 			}
 		}
 	}, [mainScreen, client])
-	const clearQuery = useCallback(() => {
+	const clearQuery = () => {
 		client.store.currentRoomListQuery = ""
 		directSetQuery("")
 		searchInputRef.current?.focus()
-	}, [client.store])
-	useEffect(() => {
-		if (!query) return
-		const onCapture = (evt: KeyboardEvent) => {
-			if (evt.key !== "Escape") return
-			if ((evt.target as Element)?.closest?.(".overlay.modal")) return
-			evt.stopPropagation()
-			evt.preventDefault()
-			clearQuery()
-		}
-		document.addEventListener("keydown", onCapture, { capture: true })
-		return () => document.removeEventListener("keydown", onCapture, { capture: true })
-	}, [query, clearQuery])
+	}
 	const onKeyDown = (evt: React.KeyboardEvent<HTMLInputElement>) => {
 		const key = keyToString(evt)
-		if (key === "Enter") {
+		if (key === "Escape") {
+			clearQuery()
+			evt.stopPropagation()
+			evt.preventDefault()
+		} else if (key === "Enter") {
 			const roomList = client.store.getFilteredRoomList()
 			mainScreen.setActiveRoom(roomList[roomList.length-1]?.room_id)
 			client.store.currentRoomListQuery = ""
@@ -145,7 +137,14 @@ const RoomList = ({ activeRoomID, space }: RoomListProps) => {
 
 	const showInviteAvatars = usePreference(client.store, null, "show_invite_avatars")
 	const roomListFilter = client.store.roomListFilterFunc
-	return <div className="room-list-wrapper">
+	const onWrapperKeyDown = (evt: React.KeyboardEvent<HTMLDivElement>) => {
+		if (keyToString(evt) === "Escape" && query !== "") {
+			clearQuery()
+			evt.stopPropagation()
+			evt.preventDefault()
+		}
+	}
+	return <div className="room-list-wrapper" onKeyDown={onWrapperKeyDown}>
 		<div className="room-search-wrapper">
 			<input
 				value={query}

--- a/web/src/ui/roomlist/RoomList.tsx
+++ b/web/src/ui/roomlist/RoomList.tsx
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-import React, { use, useCallback, useRef, useState } from "react"
+import React, { use, useCallback, useEffect, useRef, useState } from "react"
 import { BarLoader } from "react-spinners"
 import { getAvatarThumbnailURL } from "@/api/media.ts"
 import { RoomListFilter, Space as SpaceStore, SpaceUnreadCounts, usePreference } from "@/api/statestore"
@@ -113,18 +113,26 @@ const RoomList = ({ activeRoomID, space }: RoomListProps) => {
 			}
 		}
 	}, [mainScreen, client])
-	const clearQuery = () => {
+	const clearQuery = useCallback(() => {
 		client.store.currentRoomListQuery = ""
 		directSetQuery("")
 		searchInputRef.current?.focus()
-	}
-	const onKeyDown = (evt: React.KeyboardEvent<HTMLInputElement>) => {
-		const key = keyToString(evt)
-		if (key === "Escape") {
-			clearQuery()
+	}, [client.store])
+	useEffect(() => {
+		if (!query) return
+		const onCapture = (evt: KeyboardEvent) => {
+			if (evt.key !== "Escape") return
+			if ((evt.target as Element)?.closest?.(".overlay.modal")) return
 			evt.stopPropagation()
 			evt.preventDefault()
-		} else if (key === "Enter") {
+			clearQuery()
+		}
+		document.addEventListener("keydown", onCapture, { capture: true })
+		return () => document.removeEventListener("keydown", onCapture, { capture: true })
+	}, [query, clearQuery])
+	const onKeyDown = (evt: React.KeyboardEvent<HTMLInputElement>) => {
+		const key = keyToString(evt)
+		if (key === "Enter") {
 			const roomList = client.store.getFilteredRoomList()
 			mainScreen.setActiveRoom(roomList[roomList.length-1]?.room_id)
 			clearQuery()
@@ -135,14 +143,7 @@ const RoomList = ({ activeRoomID, space }: RoomListProps) => {
 
 	const showInviteAvatars = usePreference(client.store, null, "show_invite_avatars")
 	const roomListFilter = client.store.roomListFilterFunc
-	const onWrapperKeyDown = (evt: React.KeyboardEvent<HTMLDivElement>) => {
-		if (keyToString(evt) === "Escape" && query !== "") {
-			clearQuery()
-			evt.stopPropagation()
-			evt.preventDefault()
-		}
-	}
-	return <div className="room-list-wrapper" onKeyDown={onWrapperKeyDown}>
+	return <div className="room-list-wrapper">
 		<div className="room-search-wrapper">
 			<input
 				value={query}

--- a/web/src/ui/roomview/roomcontext.ts
+++ b/web/src/ui/roomview/roomcontext.ts
@@ -26,6 +26,7 @@ const noop = (name: string) => () => {
 export class RoomContextData {
 	public readonly timelineBottomRef: RefObject<HTMLDivElement | null> = createRef()
 	public setReplyTo: (eventID: EventID | null) => void = noop("setReplyTo")
+	public setReplyToAsThread: (eventID: EventID) => void = noop("setReplyToAsThread")
 	public setEditing: (evt: MemDBEvent | null) => void = noop("setEditing")
 	public insertText: (text: string) => void = noop("insertText")
 	public lastThreadEventID: EventID | null = null

--- a/web/src/ui/timeline/ReplyBody.css
+++ b/web/src/ui/timeline/ReplyBody.css
@@ -143,7 +143,7 @@ blockquote.reply-body {
 				}
 
 				&.mode-active {
-					background-color: var(--timeline-hover-bg-color);
+					background-color: var(--button-hover-color);
 				}
 			}
 		}

--- a/web/src/ui/timeline/ReplyBody.css
+++ b/web/src/ui/timeline/ReplyBody.css
@@ -141,7 +141,8 @@ blockquote.reply-body {
 					height: 24px;
 					width: 24px;
 				}
-			}
+
+				}
 		}
 	}
 

--- a/web/src/ui/timeline/ReplyBody.css
+++ b/web/src/ui/timeline/ReplyBody.css
@@ -142,7 +142,10 @@ blockquote.reply-body {
 					width: 24px;
 				}
 
+				&.mode-active {
+					background-color: var(--timeline-hover-bg-color);
 				}
+			}
 		}
 	}
 

--- a/web/src/ui/timeline/ReplyBody.tsx
+++ b/web/src/ui/timeline/ReplyBody.tsx
@@ -53,7 +53,7 @@ interface ReplyBodyProps {
 	isExplicitInThread?: boolean
 	onSetExplicitInThread?: (evt: React.MouseEvent) => void
 	startNewThread?: boolean
-	onSetStartNewThread?: (evt: React.MouseEvent) => void
+	onSetStartNewThread?: (value: boolean | React.MouseEvent) => void
 }
 
 interface ReplyIDBodyProps {
@@ -181,16 +181,22 @@ export const ReplyBody = ({
 				>
 					{isExplicitInThread ? <ReplyIcon /> : <ThreadIcon />}
 				</TooltipButton>}
-				{!isThread && onSetStartNewThread && <TooltipButton
-					tooltipText={startNewThread
-						? "Click to reply in main timeline instead of starting a new thread"
-						: "Click to start a new thread instead of replying"}
-					tooltipDirection="left"
-					className="thread-explicit-reply"
-					onClick={onSetStartNewThread}
-				>
-					{startNewThread ? <ThreadIcon /> : <ReplyIcon />}
-				</TooltipButton>}
+				{!isThread && onSetStartNewThread && <>
+					<TooltipButton
+						tooltipText="Reply in main timeline"
+						tooltipDirection="left"
+						onClick={evt => { evt.stopPropagation(); onSetStartNewThread(false) }}
+					>
+						<ReplyIcon />
+					</TooltipButton>
+					<TooltipButton
+						tooltipText="Start new thread"
+						tooltipDirection="left"
+						onClick={evt => { evt.stopPropagation(); onSetStartNewThread(true) }}
+					>
+						<ThreadIcon />
+					</TooltipButton>
+				</>}
 				{onClose && <button className="close-reply" onClick={onClose}><CloseIcon/></button>}
 			</div>}
 		</div>

--- a/web/src/ui/timeline/ReplyBody.tsx
+++ b/web/src/ui/timeline/ReplyBody.tsx
@@ -84,7 +84,7 @@ export const ReplyBody = ({
 	timelineThreadMsg, reactions,
 	isSilent, onSetSilent,
 	isExplicitInThread, onSetExplicitInThread,
-	startNewThread, onSetStartNewThread,
+	onSetStartNewThread,
 }: ReplyBodyProps) => {
 	const room = roomCtx.store
 	const client = use(ClientContext)

--- a/web/src/ui/timeline/ReplyBody.tsx
+++ b/web/src/ui/timeline/ReplyBody.tsx
@@ -84,7 +84,7 @@ export const ReplyBody = ({
 	timelineThreadMsg, reactions,
 	isSilent, onSetSilent,
 	isExplicitInThread, onSetExplicitInThread,
-	onSetStartNewThread,
+	startNewThread, onSetStartNewThread,
 }: ReplyBodyProps) => {
 	const room = roomCtx.store
 	const client = use(ClientContext)
@@ -185,6 +185,7 @@ export const ReplyBody = ({
 					<TooltipButton
 						tooltipText="Reply in main timeline"
 						tooltipDirection="left"
+						className={!startNewThread ? "mode-active" : undefined}
 						onClick={evt => { evt.stopPropagation(); onSetStartNewThread(false) }}
 					>
 						<ReplyIcon />
@@ -192,6 +193,7 @@ export const ReplyBody = ({
 					<TooltipButton
 						tooltipText="Start new thread"
 						tooltipDirection="left"
+						className={startNewThread ? "mode-active" : undefined}
 						onClick={evt => { evt.stopPropagation(); onSetStartNewThread(true) }}
 					>
 						<ThreadIcon />


### PR DESCRIPTION
### Checklist

* [X] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>

Many users alternate between replying to individual messages and starting threads. The current implementation requires two mouse clicks or finger taps to start a thread. This is particularly awkward on mobile where the button is small. I suggest a more usable implementation would be to include both buttons on the hover toolbar. This patch does exactly that.