### PR TITLE
web/emojipicker: fix subscribing to packs with an empty string as the state key

### DIFF
--- a/web/src/api/types/hitypes.ts
+++ b/web/src/api/types/hitypes.ts
@@ -245,13 +245,13 @@ export function stringToRoomStateGUID(str?: string | null): RoomStateGUID | unde
 		return
 	}
 	const [roomID, type, stateKey] = str.split("/")
-	if (!roomID || !type || !stateKey) {
+	if (!roomID || !type) {
 		return
 	}
 	return {
 		room_id: decodeURIComponent(roomID) as RoomID,
 		type: type as EventType,
-		state_key: decodeURIComponent(stateKey),
+		state_key: decodeURIComponent(stateKey ?? ""),
 	}
 }
 


### PR DESCRIPTION
This pull request fixes subscribing to emoji packs with an empty state key in the `m.room.image_pack` state event.

See [MSC2545](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/2545-emotes.md):

> This proposal does not associate any special property with
> an empty string for an image pack's `state_key`.

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
