### PR TITLE
license: add exception for app store distribution

### DIFF
--- a/LICENSE.iOS
+++ b/LICENSE.iOS
@@ -1,0 +1,8 @@
+Additional Permissions For Submission to Apple App Store: Provided that you are
+otherwise in compliance with the AGPLv3 for each covered work you convey
+(including without limitation making the Corresponding Source available in
+compliance with Section 6 of the AGPLv3), the gomuks developers also grant
+you the additional permission to convey through the Apple App Store non-source
+executable versions of the Program as incorporated into each applicable covered
+work as Executable Versions only under the Mozilla Public License version 2.0
+(https://www.mozilla.org/en-US/MPL/2.0/).


### PR DESCRIPTION
Based on the exception in <https://github.com/signalapp/libsignal-protocol-c>'s readme

There are non-trivial contributions from:

* [x] @char-mines 
* [x] @JadedBlueEyes 
* [x] @kittyandrew 
* [x] @timedoutuk 
* [x] @sumnerevans 

If you're listed above, please comment on this PR to confirm you're fine with the exception